### PR TITLE
Rewrite styled components to new prefix

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,33 +5,28 @@ import { ConstraintSection } from './Layout/ConstraintSection'
 import { ChartSection, TableSection } from './Layout/DataVizSection'
 import { Header } from './Layout/Header'
 
-const StyledTableChartsSection = styled.section`
+const S_TableChartsSection = styled.section`
 	padding: 10px 30px 0;
 	overflow: auto;
 	height: calc(100vh - 3.643em);
 `
 
-const Main = styled.main`
+const S_Main = styled.main`
 	display: grid;
 	grid-template-columns: 230px 1fr;
 `
-
-const S = {
-	Main,
-	TableChartsSection: StyledTableChartsSection,
-}
 
 export const App = () => {
 	return (
 		<div className="light-theme">
 			<Header />
-			<S.Main>
+			<S_Main>
 				<ConstraintSection />
-				<S.TableChartsSection>
+				<S_TableChartsSection>
 					<ChartSection />
 					<TableSection />
-				</S.TableChartsSection>
-			</S.Main>
+				</S_TableChartsSection>
+			</S_Main>
 		</div>
 	)
 }

--- a/src/components/Constraints/ConstraintBase.jsx
+++ b/src/components/Constraints/ConstraintBase.jsx
@@ -4,7 +4,7 @@ import { styled } from 'linaria/react'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const CountTag = styled.div`
+const S_CountTag = styled.div`
 	display: flex;
 	align-self: flex-start;
 	margin-left: 5px;
@@ -20,18 +20,18 @@ const CountTag = styled.div`
 	}
 `
 
-const TagIcon = styled(Icon)`
+const S_TagIcon = styled(Icon)`
 	/* We need to override Blueprint styling to create our pill */
 	margin: -0.167em -0.167em !important;
 	align-self: flex-start;
 `
 
-const ConstraintLabel = styled.div`
+const S_ConstraintLabel = styled.div`
 	display: flex;
 	align-items: center;
 `
 
-const ConstraintIcon = styled.div`
+const S_ConstraintIcon = styled.div`
 	border-radius: 30px;
 	border: ${(props) => `0.167em solid ${props.labelBorderColor}`};
 	font-size: var(--fs-desktopS1);
@@ -44,13 +44,6 @@ const ConstraintIcon = styled.div`
 	align-items: center;
 	justify-content: center;
 `
-
-const S = {
-	ConstraintLabel,
-	ConstraintIcon,
-	CountTag,
-	TagIcon,
-}
 
 /**
  * A constraint is styled as a button that takes the full width of its container. Each
@@ -75,18 +68,18 @@ export const Constraint = ({
 			alignText="left"
 			aria-label={ariaLabel ? ariaLabel : constraintName}
 		>
-			<S.ConstraintLabel>
-				<S.ConstraintIcon labelBorderColor={labelBorderColor}>
+			<S_ConstraintLabel>
+				<S_ConstraintIcon labelBorderColor={labelBorderColor}>
 					<span>{labelText}</span>
-				</S.ConstraintIcon>
+				</S_ConstraintIcon>
 				{constraintName}
 				{constraintCount > 0 && (
-					<S.CountTag>
+					<S_CountTag>
 						{constraintCount > 1 && <small>{constraintCount}</small>}
-						<S.TagIcon icon={IconNames.TICK_CIRCLE} color="var(--green5)" />
-					</S.CountTag>
+						<S_TagIcon icon={IconNames.TICK_CIRCLE} color="var(--green5)" />
+					</S_CountTag>
 				)}
-			</S.ConstraintLabel>
+			</S_ConstraintLabel>
 		</Button>
 	)
 }

--- a/src/components/Layout/ConstraintSection.jsx
+++ b/src/components/Layout/ConstraintSection.jsx
@@ -4,28 +4,22 @@ import React from 'react'
 import * as Constraints from '../Constraints'
 import { QueryController } from '../QueryController'
 
-const ConstraintWrapper = styled.li`
+const S_Constraint = styled.li`
 	margin: 0.875em 0;
 `
 
-const ConstraintList = styled.ul`
+const S_ConstraintList = styled.ul`
 	overflow: auto;
 	list-style: none;
 	padding: 0;
 	height: 77vh;
 `
 
-const ConstraintSectionWrapper = styled.section`
+const S_ConstraintSection = styled.section`
 	min-width: 230px;
 	border-right: 2px solid var(--blue5);
 	background-color: var(--solidWhite);
 `
-
-const S = {
-	Constraint: ConstraintWrapper,
-	ConstraintSection: ConstraintSectionWrapper,
-	ConstraintList,
-}
 
 const constraintMocks = [
 	Constraints.INTERMINE_LIST,
@@ -47,13 +41,13 @@ const constraintMocks = [
 
 export const ConstraintSection = () => {
 	return (
-		<S.ConstraintSection>
+		<S_ConstraintSection>
 			<QueryController />
-			<S.ConstraintList>
+			<S_ConstraintList>
 				{constraintMocks.map((c, idx) => (
-					<S.Constraint key={idx}>{Constraints.renderConstraint(c)}</S.Constraint>
+					<S_Constraint key={idx}>{Constraints.renderConstraint(c)}</S_Constraint>
 				))}
-			</S.ConstraintList>
-		</S.ConstraintSection>
+			</S_ConstraintList>
+		</S_ConstraintSection>
 	)
 }

--- a/src/components/Layout/DataVizSection.jsx
+++ b/src/components/Layout/DataVizSection.jsx
@@ -17,13 +17,13 @@ const S_ChartContainer = styled.div`
 	width: 45%;
 `
 
-const TableCard = styled(Card)`
+const S_TableCard = styled(Card)`
 	margin-bottom: 20px;
 	overflow: scroll;
 	padding-bottom: unset;
 `
 
-const StyledRowCount = styled.span`
+const S_RowCount = styled.span`
 	font-size: var(--fs-desktopM1);
 	font-weight: var(--fw-semibold);
 	margin-bottom: 20px;
@@ -31,23 +31,16 @@ const StyledRowCount = styled.span`
 	display: inline-block;
 `
 
-const StyledPagingRow = styled.div`
+const S_PagingRow = styled.div`
 	display: flex;
 	justify-content: space-between;
 `
 
-const StyledTableChartsSection = styled.section`
+const S_TableChartSection = styled.section`
 	padding: 10px 30px 0;
 	overflow: auto;
 	height: calc(100vh - 3.643em);
 `
-
-const S = {
-	TableCard,
-	RowCount: StyledRowCount,
-	PagingRow: StyledPagingRow,
-	TableChartSection: StyledTableChartsSection,
-}
 
 export const ChartSection = () => {
 	return (
@@ -67,23 +60,23 @@ export const ChartSection = () => {
 export const TableSection = () => {
 	return (
 		<section>
-			<S.TableCard>
+			<S_TableCard>
 				<TableActionButtons />
-				<S.PagingRow>
-					<S.RowCount>{`Showing ${rows.length} of ${rows.length} rows`}</S.RowCount>
+				<S_PagingRow>
+					<S_RowCount>{`Showing ${rows.length} of ${rows.length} rows`}</S_RowCount>
 					<TablePagingButtons />
-				</S.PagingRow>
+				</S_PagingRow>
 				<Table mineUrl={mineUrl} rows={rows} />
-			</S.TableCard>
+			</S_TableCard>
 		</section>
 	)
 }
 
 export const TableChartSection = () => {
 	return (
-		<S.TableChartSection id="Tablechart">
+		<S_TableChartSection id="Tablechart">
 			<ChartSection />
 			<TableSection />
-		</S.TableChartSection>
+		</S_TableChartSection>
 	)
 }

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -4,12 +4,12 @@ import React from 'react'
 import logo from '../../images/logo.png'
 import { NavigationBar } from '../NavBar/NavBar'
 
-const StyledHeader = styled.header`
+const S_Header = styled.header`
 	display: inline-flex;
 	width: 100%;
 `
 
-const LogoContainter = styled.div`
+const S_LogoContainter = styled.div`
 	min-width: 230px;
 	height: 43px;
 	display: inline-flex;
@@ -19,20 +19,15 @@ const LogoContainter = styled.div`
 	border-bottom: 2px solid var(--blue5);
 `
 
-const S = {
-	Header: StyledHeader,
-	LogoContainter,
-}
-
 export const Header = () => {
 	return (
 		<>
-			<S.Header>
-				<S.LogoContainter>
+			<S_Header>
+				<S_LogoContainter>
 					<img width="120px" src={logo} alt="Logo" />
-				</S.LogoContainter>
+				</S_LogoContainter>
 				<NavigationBar />
-			</S.Header>
+			</S_Header>
 		</>
 	)
 }

--- a/src/components/NavBar/ApiStatus.jsx
+++ b/src/components/NavBar/ApiStatus.jsx
@@ -2,7 +2,7 @@ import { Button, Colors, Icon } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React, { useState } from 'react'
 
-import * as S from './FormGroups'
+import { S_NavFormGroup } from './FormGroups'
 
 const AuthenticatedIcon = (isAuthenticated) => (
 	<Icon
@@ -14,13 +14,13 @@ const AuthenticatedIcon = (isAuthenticated) => (
 export const ApiStatus = () => {
 	const [isAuthenticated, setAuthentication] = useState(false)
 	return (
-		<S.NavFormGroup label="Api" inline={true} labelFor="api-status">
+		<S_NavFormGroup label="Api" inline={true} labelFor="api-status">
 			<Button
 				aria-label="api-status"
 				small={true}
 				icon={AuthenticatedIcon(isAuthenticated)}
 				onClick={() => setAuthentication(!isAuthenticated)}
 			/>
-		</S.NavFormGroup>
+		</S_NavFormGroup>
 	)
 }

--- a/src/components/NavBar/ClassSelector.jsx
+++ b/src/components/NavBar/ClassSelector.jsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react'
 
 import { NumberedSelectMenuItems } from '../Selects'
 
-const StyledTabs = styled(Tabs)`
+const S_Tabs = styled(Tabs)`
 	margin-left: auto;
 	margin-right: 20px;
 
@@ -15,10 +15,6 @@ const StyledTabs = styled(Tabs)`
 		font-weight: var(--fw-light);
 	}
 `
-
-const S = {
-	Tabs: StyledTabs,
-}
 
 export const ClassSelector = () => {
 	const [visibleClasses, setVisibleClasses] = useState([{ name: 'Gene' }, { name: 'Protein' }])
@@ -35,11 +31,11 @@ export const ClassSelector = () => {
 
 	return (
 		<>
-			<S.Tabs id="classes-tab" large={true}>
+			<S_Tabs id="classes-tab" large={true}>
 				{visibleClasses.map((c) => (
 					<Tab key={c.name} id={c.name} title={c.name} />
 				))}
-			</S.Tabs>
+			</S_Tabs>
 			<Select
 				items={hiddenClasses}
 				filterable={true}

--- a/src/components/NavBar/FormGroups.jsx
+++ b/src/components/NavBar/FormGroups.jsx
@@ -1,7 +1,7 @@
 import { Classes, FormGroup } from '@blueprintjs/core'
 import { styled } from 'linaria/react'
 
-export const NavFormGroup = styled(FormGroup)`
+export const S_NavFormGroup = styled(FormGroup)`
 	margin: unset;
 
 	&& > label.${Classes.LABEL} {

--- a/src/components/NavBar/MineSelect.jsx
+++ b/src/components/NavBar/MineSelect.jsx
@@ -5,11 +5,11 @@ import { css } from 'linaria'
 import React from 'react'
 
 import { NumberedSelectMenuItems } from '../Selects'
-import * as S from './FormGroups'
+import { S_NavFormGroup } from './FormGroups'
 
 export const Mine = ({ mine, mockMines, setMine }) => {
 	return (
-		<S.NavFormGroup label="Mine" inline={true} labelFor="mine-select-button">
+		<S_NavFormGroup label="Mine" inline={true} labelFor="mine-select-button">
 			<Select
 				className={css`
 					margin-right: 30px;
@@ -30,6 +30,6 @@ export const Mine = ({ mine, mockMines, setMine }) => {
 					rightIcon={IconNames.CARET_DOWN}
 				/>
 			</Select>
-		</S.NavFormGroup>
+		</S_NavFormGroup>
 	)
 }

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -9,13 +9,9 @@ import { ClassSelector } from './ClassSelector'
 import { Mine } from './MineSelect'
 import { ThemeControl } from './ThemeControl'
 
-const StyledNav = styled(Navbar)`
+const S_Navbar = styled(Navbar)`
 	padding: 0 30px 30px 40px;
 `
-
-const S = {
-	Navbar: StyledNav,
-}
 
 export const NavigationBar = () => {
 	const [mockMines] = useState([
@@ -26,7 +22,7 @@ export const NavigationBar = () => {
 	const [mine, setMine] = useState(mockMines[0])
 
 	return (
-		<S.Navbar>
+		<S_Navbar>
 			<Navbar.Group
 				className={css`
 					width: 100%;
@@ -46,6 +42,6 @@ export const NavigationBar = () => {
 					icon={IconNames.ERROR}
 				/>
 			</Navbar.Group>
-		</S.Navbar>
+		</S_Navbar>
 	)
 }

--- a/src/components/QueryController.jsx
+++ b/src/components/QueryController.jsx
@@ -4,19 +4,14 @@ import { css } from 'linaria'
 import { styled } from 'linaria/react'
 import React from 'react'
 
-const StyledQueryController = styled.div`
+const S_QueryController = styled.div`
 	padding-top: 10px;
 	margin: 0 20px;
 `
 
-const StyledHeading = styled.span`
+const S_Heading = styled.span`
 	color: var(--blue9);
 `
-
-const S = {
-	Heading: StyledHeading,
-	QueryController: StyledQueryController,
-}
 
 const ViewAll = () => (
 	<Popover fill={true} usePortal={true} lazy={true} position="right">
@@ -42,7 +37,7 @@ const RunQuery = () => (
 
 export const QueryController = () => {
 	return (
-		<S.QueryController>
+		<S_QueryController>
 			<H5>
 				<span
 					className={css`
@@ -51,10 +46,10 @@ export const QueryController = () => {
 				>
 					4{' '}
 				</span>
-				<S.Heading>Constraints applied</S.Heading>
+				<S_Heading>Constraints applied</S_Heading>
 			</H5>
 			<ViewAll />
 			<RunQuery />
-		</S.QueryController>
+		</S_QueryController>
 	)
 }


### PR DESCRIPTION
## What I did

I refactored all our styled components to use the `S_` prefix. This way we can get static checking and still know if a component is styled react component vs a regular react component.

Closes #33 