### PR TITLE
Remove selected items from popover values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log*
 
 # Storybook
 .storybook-dist
+storybook-dist
+
 # Local Netlify folder
 .netlify
 

--- a/src/components/Constraints/SelectPopup.jsx
+++ b/src/components/Constraints/SelectPopup.jsx
@@ -53,7 +53,7 @@ export const SelectPopup = ({
 
 	const filterQuery = (query, items) => {
 		if (query === '') {
-			return items
+			return items.filter((i) => !selectedValues.includes(i.name))
 		}
 
 		const fuseResults = fuse.current.search(query)

--- a/src/components/Constraints/SelectPopup.jsx
+++ b/src/components/Constraints/SelectPopup.jsx
@@ -1,4 +1,4 @@
-import { Button, Classes, Divider, FormGroup, H4 } from '@blueprintjs/core'
+import { Button, Classes, Divider, FormGroup, H4, MenuItem } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import { Suggest } from '@blueprintjs/select'
 import Fuse from 'fuse.js'
@@ -39,8 +39,8 @@ export const SelectPopup = ({
 		unselectedItems = [{ name: 'No items match your search', item: '' }]
 	}
 
-	// Blueprintjs requires a value renderer, but we add the value directly to the
-	// added constraints list when clicked
+	// Blueprintjs requires a value renderer to display a value when selected. But we add
+	// the value directly to the added constraints list when clicked, so we reset the input here
 	const renderInputValue = () => ''
 
 	const handleItemSelect = ({ name }) => {
@@ -109,6 +109,7 @@ export const SelectPopup = ({
 					fill={true}
 					onItemSelect={handleItemSelect}
 					resetOnSelect={true}
+					noResults={<MenuItem disabled={true} text="No results match your entry" />}
 				/>
 			</FormGroup>
 		</div>

--- a/src/components/Constraints/SelectPopup.jsx
+++ b/src/components/Constraints/SelectPopup.jsx
@@ -22,21 +22,14 @@ export const SelectPopup = ({
 	const fuse = useRef(new Fuse([]))
 
 	useEffect(() => {
-		const origValues = [...availableValues]
-
-		fuse.current = new Fuse(origValues, {
+		fuse.current = new Fuse(availableValues, {
 			keys: ['item'],
+			useExtendedSearch: true,
 		})
 	}, [availableValues])
 
 	if (availableValues.length === 0) {
 		return <NoValuesProvided title={nonIdealTitle} description={nonIdealDescription} />
-	}
-
-	let unselectedItems = availableValues.map((i) => ({ name: i.item, count: i.count }))
-
-	if (unselectedItems.length === 0) {
-		unselectedItems = [{ name: 'No items match your search', item: '' }]
 	}
 
 	// Blueprintjs requires a value renderer to display a value when selected. But we add
@@ -57,7 +50,13 @@ export const SelectPopup = ({
 		}
 
 		const fuseResults = fuse.current.search(query)
-		return fuseResults.map((r) => ({ name: r.item.item, count: r.item.count }))
+		return fuseResults.flatMap((r) => {
+			if (selectedValues.includes(r.item.item)) {
+				return []
+			}
+
+			return [{ name: r.item.item, count: r.item.count }]
+		})
 	}
 
 	return (
@@ -102,7 +101,7 @@ export const SelectPopup = ({
 				<Suggest
 					// @ts-ignore
 					id={`selectPopup-${uniqueId}`}
-					items={unselectedItems}
+					items={availableValues.map((i) => ({ name: i.item, count: i.count }))}
 					itemRenderer={PlainSelectMenuItems}
 					inputValueRenderer={renderInputValue}
 					itemListPredicate={filterQuery}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,13 @@
 		"strict": false
 	},
 	"include": ["src/**/*"],
-	"exclude": ["**/node_modules/*", "src/blueprintIcons.js"],
+	"exclude": [
+		"**/node_modules/*",
+		"src/blueprintIcons.js",
+		"build",
+		"orig_app",
+		"storybook-dist",
+		"docs"
+	],
 	"typeRoots": ["./node_modules/@types"]
 }


### PR DESCRIPTION
## What I did

This PR fixes a regression where the user could still see fuzzy search results for items that had already been collected. I also moved the fuzzy search logic inside the `itemListPredicate` prop for the suggest, since they already handled updating the filtered dropdown list.

Closes: #56