### PR TITLE
Remove previous constraint when applying updated changes

### DIFF
--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -51,7 +51,12 @@ export const queryControllerMachine = Machine(
 		actions: {
 			// @ts-ignore
 			addConstraint: assign((ctx, { query }) => {
-				ctx.currentConstraints.push(query)
+				const withQueryRemoved = ctx.currentConstraints.filter((c) => {
+					return c.path !== query.path
+				})
+
+				withQueryRemoved.push(query)
+				ctx.currentConstraints = withQueryRemoved
 			}),
 			// @ts-ignore
 			removeConstraint: assign((ctx, { type, query }) => {


### PR DESCRIPTION
A duplicate constraint is created when applied, updated, and then
applied again. This commit filters the constraints to remove any that
match the path of the one being applied.

Closes: #68

