### PR TITLE
Load the default queries when loading the app

### DIFF
--- a/orig_app/javascripts/api-requests.min.js
+++ b/orig_app/javascripts/api-requests.min.js
@@ -549,7 +549,6 @@ function getItemsInClass(className, constraints) {
             root: escapeMineURL(window.mineUrl)
         });
 
-        console.log({constraints})
         if (className == "Gene") {
             var query = {
                 "constraintLogic": "(A OR B OR C OR D OR E OR F OR G OR H OR I OR J) AND (K) AND (L) AND (M) AND (N) AND (O) AND (P) AND (Q) AND (R) AND (O AND S) AND (T AND U AND V) AND (W AND X AND Y AND Z)",

--- a/orig_app/javascripts/common.min.js
+++ b/orig_app/javascripts/common.min.js
@@ -1428,8 +1428,6 @@ function updatePieChart(result, pieChartID) {
         }
     };
 
-    console.log({result, minePreferredOrganisms, resultantElements, countPreferredOrganismsAdded, countData, pieOptions})
-
     window.pieChartObject = new Chart(ctx, {
         type: 'pie',
         data: {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"immer": "^7.0.5",
 		"nanoid": "^3.1.10",
 		"nanoid-dictionary": "^3.0.0",
+		"object-hash": "^2.0.3",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"recharts": "^1.8.5",

--- a/src/actionConstants.js
+++ b/src/actionConstants.js
@@ -2,6 +2,8 @@
  * global - can be used by anyone
  */
 export const RECEIVE_SUMMARY = 'global/fetch/receive_summary'
+export const FETCH_UPDATED_SUMMARY = 'global/fetch/updated_summary'
+export const FETCH_INITIAL_SUMMARY = 'global/fetch/initial_summary'
 
 export const LOCK_ALL_CONSTRAINTS = 'global/contraint/limit_reached'
 export const RESET_ALL_CONSTRAINTS = 'global/constraint/remove_all'
@@ -18,7 +20,14 @@ export const ADD_QUERY_CONSTRAINT = 'queryController/constraint/add'
 /**
  * constraints
  */
-export const ADD_CONSTRAINT = 'checkbox/constraint/add'
-export const REMOVE_CONSTRAINT = 'checkbox/constraint/remove'
-export const APPLY_CONSTRAINT = 'checkbox/constraint/apply'
-export const RESET_LOCAL_CONSTRAINT = 'checkbox/constraint/reset'
+export const ADD_CONSTRAINT = 'constraintFactory/add'
+export const REMOVE_CONSTRAINT = 'constraintFactory/remove'
+export const APPLY_CONSTRAINT = 'constraintFactory/apply'
+export const RESET_LOCAL_CONSTRAINT = 'constraintFactory/reset'
+
+export const FETCH_CONSTRAINT_ITEMS = 'constraintFactory/init'
+
+/**
+ * Pie Chart
+ */
+export const SET_INITIAL_ORGANISMS = 'pieChart/fetch/initial'

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,34 +1,59 @@
 // import so that the IDE can add the css prop to components
 import '@emotion/core'
 
-import React from 'react'
+import React, { createContext, useContext, useEffect } from 'react'
+import { FETCH_INITIAL_SUMMARY } from 'src/actionConstants'
+import { sendToBus } from 'src/machineBus'
 
 import { ConstraintSection } from './Layout/ConstraintSection'
 import { ChartSection, TableSection } from './Layout/DataVizSection'
 import { Header } from './Layout/Header'
 
+const GlobalConfig = createContext(null)
+
+export const useGlobalSetup = () => {
+	const globalConfig = useContext(GlobalConfig)
+
+	if (globalConfig === null) {
+		throw Error('There are no global values set for the root url or classview')
+	}
+
+	return globalConfig
+}
+
 export const App = () => {
+	const globalConfig = {
+		rootUrl: 'https://www.humanmine.org/humanmine',
+		classView: 'Gene',
+	}
+
+	useEffect(() => {
+		sendToBus({ type: FETCH_INITIAL_SUMMARY, globalConfig })
+	}, [globalConfig])
+
 	return (
-		<div className="light-theme">
-			<Header />
-			<main
-				css={{
-					display: 'grid',
-					gridTemplateColumns: '230px 1fr',
-				}}
-			>
-				<ConstraintSection />
-				<section
+		<GlobalConfig.Provider value={globalConfig}>
+			<div className="light-theme">
+				<Header />
+				<main
 					css={{
-						padding: '10px 30px 0',
-						overflow: 'auto',
-						height: 'calc(100vh - 3.643em)',
+						display: 'grid',
+						gridTemplateColumns: '230px 1fr',
 					}}
 				>
-					<ChartSection />
-					<TableSection />
-				</section>
-			</main>
-		</div>
+					<ConstraintSection />
+					<section
+						css={{
+							padding: '10px 30px 0',
+							overflow: 'auto',
+							height: 'calc(100vh - 3.643em)',
+						}}
+					>
+						<ChartSection />
+						<TableSection />
+					</section>
+				</main>
+			</div>
+		</GlobalConfig.Provider>
 	)
 }

--- a/src/components/Constraints/CheckboxPopup.jsx
+++ b/src/components/Constraints/CheckboxPopup.jsx
@@ -8,13 +8,7 @@ import { NoValuesProvided } from './NoValuesProvided'
 export const CheckboxPopup = ({ nonIdealTitle = undefined, nonIdealDescription = undefined }) => {
 	const [state, send] = useServiceContext('constraints')
 
-	const { selectedValues } = state?.context
-
-	const availableValues = [
-		// fixme: remove this mock
-		{ item: 'one species', count: 0 },
-		{ item: 'two chemics', count: 0 },
-	]
+	const { availableValues, selectedValues } = state?.context
 
 	if (availableValues.length === 0) {
 		return <NoValuesProvided title={nonIdealTitle} description={nonIdealDescription} />

--- a/src/components/Constraints/CheckboxPopup.stories.jsx
+++ b/src/components/Constraints/CheckboxPopup.stories.jsx
@@ -15,7 +15,7 @@ export default {
 
 /**
  * @param {{
- * 	initialState?: import('../../types').ConstraintMachineFactoryOpts['initial'],
+ * 	initialState?: import('../../types').ConstraintMachineOpts['initial'],
  * 	selectedValues?: string[],
  * 	availableValues?: any[],
  * 	machine?: import('../../types').ConstraintStateMachine
@@ -65,10 +65,15 @@ export const ConstraintsApplied = () => (
 )
 
 export const Playground = () => {
-	const machine = createConstraintMachine({ id: 'checkbox' }).withContext({
+	const machine = createConstraintMachine({
+		id: 'checkbox',
+		constraintItemsQuery: {},
+	}).withContext({
 		selectedValues: [],
 		availableValues: organismSummary.results,
 		constraintPath: '',
+		classView: '',
+		constraintItemsQuery: {},
 	})
 
 	return <CheckboxBuilder machine={machine} />

--- a/src/components/Constraints/Constraint.stories.jsx
+++ b/src/components/Constraints/Constraint.stories.jsx
@@ -11,7 +11,9 @@ export default {
 }
 
 export const Example = () => {
-	const [state, send] = useMachineBus(createConstraintMachine({ id: 'checkbox' }))
+	const [state, send] = useMachineBus(
+		createConstraintMachine({ id: 'checkbox', constraintItemsQuery: {} })
+	)
 
 	return (
 		<ConstraintServiceContext.Provider value={{ state, send }}>

--- a/src/components/Constraints/SelectPopup.stories.jsx
+++ b/src/components/Constraints/SelectPopup.stories.jsx
@@ -65,10 +65,15 @@ export const ConstraintsApplied = () => (
 export const Playground = () => (
 	<SelectBuilder
 		availableValues={mockResults}
-		machine={createConstraintMachine({ id: 'select' }).withContext({
+		machine={createConstraintMachine({
+			id: 'select',
+			constraintItemsQuery: {},
+		}).withContext({
 			selectedValues: [],
 			availableValues: mockResults,
 			constraintPath: '',
+			constraintItemsQuery: {},
+			classView: '',
 		})}
 	/>
 )

--- a/src/components/DataViz/DataViz.story.jsx
+++ b/src/components/DataViz/DataViz.story.jsx
@@ -25,6 +25,7 @@ const S_Card = styled(Card)`
 export const Empty = () => <></>
 
 const barMockMachine = BarChartMachine.withContext({
+	// @ts-ignore
 	lengthSummary: lengthSummary.stats,
 	results: lengthSummary.results.slice(0, lengthSummary.results.length - 1),
 })
@@ -44,7 +45,11 @@ BarChart.parameters = {
 	},
 }
 
-const pieMockMachine = PieChartMachine.withContext({ classItems: organismSummary.results })
+const pieMockMachine = PieChartMachine.withContext({
+	allClassOrganisms: organismSummary.results,
+	filteredItems: [],
+	classView: '',
+})
 
 export const PieChart = () => (
 	<MockMachineContext.Provider value={pieMockMachine}>

--- a/src/components/Layout/ConstraintSection.jsx
+++ b/src/components/Layout/ConstraintSection.jsx
@@ -8,21 +8,21 @@ import { SelectPopup } from '../Constraints/SelectPopup'
 import { DATA_VIZ_COLORS } from '../DataViz/dataVizColors'
 import { QueryController } from '../QueryController/QueryController'
 
-/** @type {{
- * 	type: import('../../types').ConstraintMachineFactoryOpts['id']
- * 	name: string
- * 	label: string
- * 	path: string
- * 	op: import('../../types').ConstraintMachineFactoryOpts['op']
- * }[]}
- * */
+/** @type {import('../../types').ConstraintConfig[]} */
 const defaultConstraints = [
 	{
 		type: 'checkbox',
 		name: 'Organism',
 		label: 'Or',
-		path: 'organism.shortname',
+		path: 'organism.shortName',
 		op: 'ONE OF',
+		valuesQuery: {
+			select: ['primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			where: [],
+		},
 	},
 	{
 		type: 'select',
@@ -30,6 +30,18 @@ const defaultConstraints = [
 		label: 'Pn',
 		path: 'pathways.name',
 		op: 'ONE OF',
+		valuesQuery: {
+			select: ['pathways.name', 'primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			orderBy: [
+				{
+					path: 'pathways.name',
+					direction: 'ASC',
+				},
+			],
+		},
 	},
 	{
 		type: 'select',
@@ -37,13 +49,27 @@ const defaultConstraints = [
 		label: 'GA',
 		path: 'goAnnotation.ontologyTerm.name',
 		op: 'ONE OF',
+		valuesQuery: {
+			select: ['goAnnotation.ontologyTerm.name', 'primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			orderBy: [
+				{
+					path: 'goAnnotation.ontologyTerm.name',
+					direction: 'ASC',
+				},
+			],
+		},
 	},
 ]
 
 const ConstraintBuilder = ({ constraintConfig, color }) => {
-	const { type, name, label, path, op } = constraintConfig
+	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
-	const [state, send] = useMachineBus(createConstraintMachine({ id: type, path, op }))
+	const [state, send] = useMachineBus(
+		createConstraintMachine({ id: type, path, op, constraintItemsQuery })
+	)
 
 	let Popup
 

--- a/src/fetchSummary.js
+++ b/src/fetchSummary.js
@@ -1,0 +1,15 @@
+import imjs from 'imjs'
+
+export const fetchSummary = async ({ rootUrl, query, path }) => {
+	console.log({ rootUrl, query, path })
+	const service = new imjs.Service({ root: rootUrl })
+	const q = new imjs.Query(query, service)
+
+	return await q.summarize(`${query.from}.${path}`)
+}
+
+export const fetchTable = async ({ rootUrl, query, page }) => {
+	const service = new imjs.Service({ root: rootUrl })
+
+	return await service.tableRows(query, page)
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,8 @@
-import { ADD_QUERY_CONSTRAINT, DELETE_QUERY_CONSTRAINT } from 'src/actionConstants'
+import {
+	ADD_QUERY_CONSTRAINT,
+	DELETE_QUERY_CONSTRAINT,
+	SET_INITIAL_ORGANISMS,
+} from 'src/actionConstants'
 import {
 	EventData,
 	EventObject,
@@ -27,6 +31,7 @@ import { LOCK_ALL_CONSTRAINTS, RESET_ALL_CONSTRAINTS } from './globalActions'
  */
 export interface ConstraintMachineSchema extends StateSchema {
 	states: {
+		init: {}
 		noConstraintsSet: {}
 		constraintsUpdated: {}
 		constraintsApplied: {}
@@ -38,6 +43,8 @@ export interface ConstraintMachineContext {
 	selectedValues: string[]
 	availableValues: any[]
 	constraintPath: string
+	classView: string
+	constraintItemsQuery: { [key: string]: any }
 }
 
 export type ConstraintEvents = EventObject &
@@ -50,6 +57,11 @@ export type ConstraintEvents = EventObject &
 		| { to?: string; type: typeof APPLY_CONSTRAINT }
 		| { to?: string; type: typeof APPLY_CONSTRAINT_TO_QUERY; query: QueryConfig }
 		| { to?: string; type: typeof DELETE_QUERY_CONSTRAINT; path: string }
+		| {
+				to?: string
+				type: typeof SET_INITIAL_ORGANISMS
+				globalConfig: { rootUrl: string; classView: string }
+		  }
 	)
 
 export type ConstraintMachineConfig = MachineConfig<
@@ -68,6 +80,34 @@ export type ConstraintStateMachine =
 			ConstraintTypeState
 	  >
 	| StateNode<ConstraintMachineContext, any, ConstraintEvents, any>
+
+type ConstraintMachineTypes = 'checkbox' | 'select'
+
+export type ConstraintMachineOpts = {
+	id: ConstraintMachineTypes
+	initial?:
+		| 'init'
+		| 'noConstraintsSet'
+		| 'constraintsUpdated'
+		| 'constraintsApplied'
+		| 'constraintLimitReached'
+	path?: string
+	op?: ImjsOperations
+	constraintItemsQuery: { [key: string]: any }
+}
+
+export type CreateConstraintMachine = (
+	options: ConstraintMachineOpts
+) => StateMachine<ConstraintMachineContext, any, ConstraintEvents, any>
+
+export type ConstraintConfig = {
+	type: ConstraintMachineTypes
+	name: string
+	label: string
+	path: string
+	op: string
+	valuesQuery: { [key: string]: any }
+}
 
 /**
  *
@@ -141,18 +181,3 @@ export type SendToBusWrapper = (
 	ConstraintMachineSchema,
 	ConstraintTypeState
 > | void
-
-type ConstraintMachineFactoryOpts = {
-	id: 'checkbox' | 'select'
-	initial?:
-		| 'noConstraintsSet'
-		| 'constraintsUpdated'
-		| 'constraintsApplied'
-		| 'constraintLimitReached'
-	path?: string
-	op?: ImjsOperations
-}
-
-export type CreateConstraintMachine = (
-	options: ConstraintMachineFactoryOpts
-) => StateMachine<ConstraintMachineContext, any, ConstraintEvents, any>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12735,6 +12735,7 @@ fsevents@^1.2.7:
     nanoid-dictionary: ^3.0.0
     node-sass: ^4.14.1
     node-sass-magic-importer: ^5.3.2
+    object-hash: ^2.0.3
     prettier: ^2.0.5
     prettier-plugin-package: ^1.0.0
     prop-types: ^15.7.2
@@ -16352,7 +16353,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-hash@npm:^2.0.1":
+"object-hash@npm:^2.0.1, object-hash@npm:^2.0.3":
   version: 2.0.3
   resolution: "object-hash@npm:2.0.3"
   checksum: e633ae67cd6c5f3cd52af5bef0fe7f25d597b415a6d92a601be0b97a47642908cf333cedfc9e848d25b6c51fd6cf6e64ff6eb3af710eae249a42f6a69ad6b12d


### PR DESCRIPTION
Currently the data being displayed was mock data. This commit calls the
correct api endpoints and feeds the component actual data to render. It
does not currently persist the state, or virtualize the menu items.

Squashed commits:
* Fetch organism available values
* Fetch pathway name available values
* Fetch GO Annotation available values
* Fetch Pie chart initial values
* Fetch BarChart initial values
* Fetch Table initial values

Closes: #70 