### PR TITLE
Fix: the view all button from throwing an error when clicked

### DIFF
--- a/src/components/Constraints/createConstraintMachine.js
+++ b/src/components/Constraints/createConstraintMachine.js
@@ -122,7 +122,7 @@ export const createConstraintMachine = ({
 					path: formatConstraintPath({ classView, path: constraintPath }),
 					values: selectedValues,
 					// used to render the constraints as a list
-					itemDescription: selectedValues.map((selected) => {
+					valuesDescription: selectedValues.map((selected) => {
 						return availableValues.find((v) => v.item === selected)
 					}),
 				}

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -54,7 +54,7 @@ const CurrentConstraints = () => {
 							</span>
 						</div>
 						<ul css={{ listStyle: 'none', paddingLeft: 36 }}>
-							{constraintConfig.itemDescription.map((value) => {
+							{constraintConfig.valuesDescription.map((value) => {
 								return (
 									<li key={value.item}>{`${getOperantSymbol(constraintConfig.op)} ${value.item} (${
 										value.count

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -71,9 +71,6 @@ export const queryControllerMachine = Machine(
 					return c.path !== query.path
 				})
 
-				if (query.itemDescription) {
-					delete query.itemDescription
-				}
 				withQueryRemoved.push(query)
 				ctx.currentConstraints = withQueryRemoved
 			}),


### PR DESCRIPTION
This was a regression that was introduced by deleting itemDescription
from the applied query. I no longer delete it, since it does not seem
to affect `imjs` queries, and we use those values to render the UI.

I also renamed the property to improve clarity of intent.

Closes: #74 