### PR TITLE
Make sendToBus the only way to send global messages

### DIFF
--- a/src/machineBus.js
+++ b/src/machineBus.js
@@ -27,13 +27,7 @@ export const useMachineBus = (machine, opts = {}) => {
 	/** @type {import('./types').SendToBusWrapper} */
 	const sendToBusWrapper = useMemo(() => {
 		return (event, payload) => {
-			const sendToAll = event?.to === '*'
-
-			if (sendToAll) {
-				return sendToBus(event, payload)
-			}
-
-			const receiver = serviceStations.get(event?.to ? event.to : service.sessionId)
+			const receiver = serviceStations.get(service.sessionId)
 
 			if (receiver) {
 				receiver.send(event, payload)


### PR DESCRIPTION
`sendToBus` is already a global event dispatcher. Instead, machines should
only send themselves messages with their `.send` method, and use
`sendToBus` to send global messages for api consistency.

Closes: #79 