### PR TITLE
Perform a query against the selected class view

### DIFF
--- a/src/actionConstants.js
+++ b/src/actionConstants.js
@@ -38,3 +38,4 @@ export const SET_INITIAL_ORGANISMS = 'pieChart/fetch/initial'
  * Supervisor
  */
 export const CHANGE_MINE = 'supervisor/mine/change'
+export const CHANGE_CLASS = 'supervisor/class/change'

--- a/src/components/Constraints/SelectPopup.jsx
+++ b/src/components/Constraints/SelectPopup.jsx
@@ -14,6 +14,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { FixedSizeList as List } from 'react-window'
 import { ADD_CONSTRAINT, REMOVE_CONSTRAINT } from 'src/actionConstants'
 import { generateId } from 'src/generateId'
+import { pluralizeFilteredCount } from 'src/utils'
 
 import { useServiceContext } from '../../machineBus'
 import { NoValuesProvided } from './NoValuesProvided'
@@ -47,12 +48,7 @@ const VirtualizedMenu = ({
 	handleItemSelect,
 }) => {
 	const listRef = useRef(null)
-
-	const isPlural = filteredItems.length > 1 ? 's' : ''
-	const infoText =
-		query === ''
-			? `Showing ${filteredItems.length} Item${isPlural}`
-			: `Found ${filteredItems.length} item${isPlural} matching "${query}"`
+	const infoText = pluralizeFilteredCount(filteredItems, query)
 
 	useEffect(() => {
 		if (listRef?.current) {

--- a/src/components/Constraints/createConstraintMachine.js
+++ b/src/components/Constraints/createConstraintMachine.js
@@ -116,9 +116,10 @@ export const createConstraintMachine = ({
 			}),
 			// @ts-ignore
 			setAvailableValues: assign((ctx, { data }) => {
-				// @ts-ignore
 				ctx.availableValues = data.items
 				ctx.classView = data.classView
+				ctx.selectedValues = []
+				ctx.searchIndex = null
 
 				if (ctx.type === 'select') {
 					// prebuild search index for the dropdown select menu

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -61,6 +61,8 @@ export const queryControllerMachine = Machine(
 		actions: {
 			// @ts-ignore
 			initializeMachine: assign((ctx, { globalConfig }) => {
+				ctx.currentConstraints = []
+				ctx.selectedPaths = []
 				ctx.classView = globalConfig.classView
 				ctx.rootUrl = globalConfig.rootUrl
 			}),

--- a/src/components/Selects.jsx
+++ b/src/components/Selects.jsx
@@ -5,7 +5,7 @@ export const NumberedSelectMenuItems = (item, props) => {
 	return (
 		<MenuItem
 			key={item.name}
-			text={`${props.index + 1}. ${item.name}`}
+			text={`${props.index + 1}. ${item?.displayName ?? item.name}`}
 			active={props.modifiers.active}
 			onClick={props.handleClick}
 		/>

--- a/src/fetchSummary.js
+++ b/src/fetchSummary.js
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import imjs from 'imjs'
 
 import { formatConstraintPath } from './utils'
@@ -15,4 +16,18 @@ export const fetchTable = async ({ rootUrl, query, page }) => {
 	const service = new imjs.Service({ root: rootUrl })
 
 	return await service.tableRows(query, page)
+}
+
+export const fetchInstances = async () => {
+	return axios.get('https://registry.intermine.org/service/instances', {
+		params: {
+			mine: 'prod',
+		},
+	})
+}
+
+export const fetchClasses = async (url) => {
+	const service = new imjs.Service({ root: url })
+
+	return await service.fetchModel()
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,11 @@
 export const noop = () => {}
 
 export const formatConstraintPath = ({ classView, path }) => `${classView}.${path}`
+
+export const pluralizeFilteredCount = (filteredItems, query) => {
+	const isPlural = filteredItems.length > 1 ? 's' : ''
+
+	return query === ''
+		? `Showing ${filteredItems.length} Item${isPlural}`
+		: `Found ${filteredItems.length} item${isPlural} matching "${query}"`
+}


### PR DESCRIPTION
When the user changes the class, the app should reinitialize with the
new query. This PR will update the query controller, default
constraints, pie chart, bar graph, and table with the new results.

Closes: #83

Squashed commits:
* Display only a Templates and ClassView tab
* Display the fetched model classes from the mine
* Use imjs to fetch models instead of axios request
* Update class tab when user selects a new one
* Reset all constraints when the class changes
* Make class list searchable