### PR TITLE
Perf: improve loading and searching UX

### DIFF
--- a/src/actionConstants.js
+++ b/src/actionConstants.js
@@ -26,7 +26,6 @@ export const ADD_CONSTRAINT = 'constraintFactory/add'
 export const REMOVE_CONSTRAINT = 'constraintFactory/remove'
 export const APPLY_CONSTRAINT = 'constraintFactory/apply'
 export const RESET_LOCAL_CONSTRAINT = 'constraintFactory/reset'
-
 export const FETCH_CONSTRAINT_ITEMS = 'constraintFactory/init'
 
 /**

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,7 +2,6 @@
 import '@emotion/core'
 
 import { assign } from '@xstate/immer'
-import FlexSearch from 'flexsearch'
 import React, { useEffect } from 'react'
 import { CHANGE_CLASS, CHANGE_MINE, FETCH_INITIAL_SUMMARY } from 'src/actionConstants'
 import { fetchClasses, fetchInstances } from 'src/fetchSummary'
@@ -65,21 +64,6 @@ const supervisorMachine = Machine(
 			setIntermines: assign((ctx, { data }) => {
 				ctx.intermines = data.intermines
 				ctx.modelClasses = data.modelClasses.sort()
-
-				// @ts-ignore
-				const searchIndex = new FlexSearch({
-					encode: 'advanced',
-					tokenize: 'reverse',
-					suggest: true,
-					cache: true,
-				})
-
-				ctx.modelClasses.forEach((item) => {
-					// @ts-ignore
-					searchIndex.add(item.displayName, item.displayName)
-				})
-
-				ctx.classSearchIndex = searchIndex
 			}),
 		},
 		services: {

--- a/src/components/Constraints/SelectPopup.jsx
+++ b/src/components/Constraints/SelectPopup.jsx
@@ -27,7 +27,7 @@ const ConstraintItem = ({ index, style, data }) => {
 	}
 
 	// subtract 1 because we're adding an informative menu item before all items
-	const name = filteredItems[index - 1].name
+	const name = filteredItems[index - 1].item
 
 	return (
 		<MenuItem
@@ -52,7 +52,7 @@ const VirtualizedMenu = ({
 
 	useEffect(() => {
 		if (listRef?.current) {
-			const itemLocation = filteredItems.findIndex((item) => item.name === activeItem.name)
+			const itemLocation = filteredItems.findIndex((item) => item.item === activeItem.name)
 			// add one to offset the menu description item
 			listRef.current.scrollToItem(itemLocation + 1)
 		}
@@ -103,10 +103,11 @@ export const SelectPopup = ({
 	nonIdealTitle = undefined,
 	nonIdealDescription = undefined,
 	label = '',
+	searchIndex,
 }) => {
 	const [uniqueId] = useState(() => `selectPopup-${generateId()}`)
 	const [state, send] = useServiceContext('constraints')
-	const { availableValues, selectedValues, searchIndex } = state.context
+	const { availableValues, selectedValues } = state.context
 
 	const isLoading = state.matches('loading')
 	if (state.matches('noConstraintItems')) {
@@ -117,22 +118,14 @@ export const SelectPopup = ({
 	// the value directly to the added constraints list when clicked, so we reset the input here
 	const renderInputValue = () => ''
 	const filterQuery = (query, items) => {
-		if (query === '') {
+		if (query === '' && searchIndex) {
 			return items.filter((i) => !selectedValues.includes(i.name))
 		}
 
 		// flexSearch's default result limit is set 1000, so we set it to the length of all items
-		const results = searchIndex.search(query, availableValues.length)
+		const results = searchIndex.current.search(query, availableValues.length)
 
-		return results.flatMap((value) => {
-			if (selectedValues.includes(value)) {
-				return []
-			}
-
-			const item = items.find((it) => it.name === value)
-
-			return [{ name: item.name, count: item.count }]
-		})
+		return results
 	}
 
 	const handleItemSelect = ({ name }) => {
@@ -191,7 +184,7 @@ export const SelectPopup = ({
 				<Suggest
 					// @ts-ignore
 					id={`selectPopup-${uniqueId}`}
-					items={availableValues.map((i) => ({ name: i.item, count: i.count }))}
+					items={availableValues}
 					inputValueRenderer={renderInputValue}
 					fill={true}
 					className={isLoading ? Classes.SKELETON : ''}

--- a/src/components/Constraints/SelectPopup.stories.jsx
+++ b/src/components/Constraints/SelectPopup.stories.jsx
@@ -33,6 +33,7 @@ const SelectBuilder = ({
 		<div css={{ maxWidth: 500, minWidth: 376 }}>
 			<ConstraintServiceContext.Provider value={{ state, send }}>
 				<ConstraintPopupCard>
+					{/* @ts-ignore */}
 					<SelectPopup label="Protein Name" />
 				</ConstraintPopupCard>
 			</ConstraintServiceContext.Provider>

--- a/src/components/Constraints/createConstraintMachine.js
+++ b/src/components/Constraints/createConstraintMachine.js
@@ -1,5 +1,4 @@
 import { assign } from '@xstate/immer'
-import FlexSearch from 'flexsearch'
 import { fetchSummary } from 'src/fetchSummary'
 import { sendToBus } from 'src/machineBus'
 import { formatConstraintPath } from 'src/utils'
@@ -120,24 +119,6 @@ export const createConstraintMachine = ({
 				ctx.classView = data.classView
 				ctx.selectedValues = []
 				ctx.searchIndex = null
-
-				if (ctx.type === 'select') {
-					// prebuild search index for the dropdown select menu
-					// @ts-ignore
-					const searchIndex = new FlexSearch({
-						encode: 'advanced',
-						tokenize: 'reverse',
-						suggest: true,
-						cache: true,
-					})
-
-					data.items.forEach((item) => {
-						// @ts-ignore
-						searchIndex.add(item.item, item.item)
-					})
-
-					ctx.searchIndex = searchIndex
-				}
 			}),
 			applyConstraint: ({ classView, constraintPath, selectedValues, availableValues }) => {
 				const query = {

--- a/src/components/Layout/ConstraintSection.jsx
+++ b/src/components/Layout/ConstraintSection.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import FlexSearch from 'flexsearch'
+import React, { useEffect, useRef } from 'react'
 
 import { ConstraintServiceContext, useMachineBus } from '../../machineBus'
 import { CheckboxPopup } from '../Constraints/CheckboxPopup'
@@ -71,6 +72,30 @@ const ConstraintBuilder = ({ constraintConfig, color }) => {
 		createConstraintMachine({ id: type, path, op, constraintItemsQuery })
 	)
 
+	const searchIndex = useRef(null)
+	const { availableValues } = state.context
+
+	useEffect(() => {
+		if (type === 'select' && searchIndex.current === null && availableValues.length > 0) {
+			// @ts-ignore
+			const index = new FlexSearch({
+				encode: 'advanced',
+				tokenize: 'reverse',
+				suggest: true,
+				cache: true,
+				doc: {
+					id: 'item',
+					field: 'item',
+				},
+			})
+
+			// @ts-ignore
+			index.add(availableValues)
+
+			searchIndex.current = index
+		}
+	}, [availableValues, type])
+
 	let Popup
 
 	switch (type) {
@@ -88,6 +113,8 @@ const ConstraintBuilder = ({ constraintConfig, color }) => {
 				<Popup
 					nonIdealTitle="No items found"
 					nonIdealDescription="If you feel this is a mistake, try refreshing the browser. If that doesn't work, let us know"
+					// @ts-ignore
+					searchIndex={searchIndex}
 				/>
 			</Constraint>
 		</ConstraintServiceContext.Provider>

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -36,7 +36,7 @@ export const NavigationBar = () => {
 	}
 
 	const filterQuery = (query, items) => {
-		if (query === '') {
+		if (query === '' || !classSearchIndex) {
 			return items
 		}
 

--- a/src/fetchSummary.js
+++ b/src/fetchSummary.js
@@ -3,8 +3,20 @@ import imjs from 'imjs'
 
 import { formatConstraintPath } from './utils'
 
+const serviceCache = {}
+
+const getService = (rootUrl) => {
+	let service = serviceCache[rootUrl]
+	if (!service) {
+		service = new imjs.Service({ root: rootUrl })
+		serviceCache[rootUrl] = service
+	}
+
+	return service
+}
+
 export const fetchSummary = async ({ rootUrl, query, path }) => {
-	const service = new imjs.Service({ root: rootUrl })
+	const service = getService(rootUrl)
 	const q = new imjs.Query(query, service)
 
 	const fullPath = formatConstraintPath({ classView: query.from, path })
@@ -13,8 +25,7 @@ export const fetchSummary = async ({ rootUrl, query, path }) => {
 }
 
 export const fetchTable = async ({ rootUrl, query, page }) => {
-	const service = new imjs.Service({ root: rootUrl })
-
+	const service = getService(rootUrl)
 	return await service.tableRows(query, page)
 }
 
@@ -26,8 +37,8 @@ export const fetchInstances = async () => {
 	})
 }
 
-export const fetchClasses = async (url) => {
-	const service = new imjs.Service({ root: url })
+export const fetchClasses = async (rootUrl) => {
+	const service = getService(rootUrl)
 
 	return await service.fetchModel()
 }


### PR DESCRIPTION
Issue 1:
Some api calls were being duplicated so the app would take 2x as long to
load. This occurred because we created new `imjs` services with each call,
which did not take advantage of caching previous results. Now we save
each service by root url in a dictionary.

Issue 2:
The constraints would create their search indexes before the app loaded.
Since some constraints returned 10s of 1000s of items, this would lead
to near 1 second operations on a fast computer. We now create the
index after the component loads. Which while still not perfect, defers
the operation till much later.

Closes: #85 