### PR TITLE
Fix: filter classes on a search query

### DIFF
--- a/src/buildSearchIndex.js
+++ b/src/buildSearchIndex.js
@@ -1,0 +1,41 @@
+import FlexSearch from 'flexsearch'
+
+import { indexWorker } from './searchIndex'
+
+export const buildSearchIndex = async ({ docId, docField, values }) => {
+	// The configuration *must* be the same for import and export
+	const indexConfig = {
+		encode: 'advanced',
+		tokenize: 'reverse',
+		suggest: true,
+		cache: true,
+		doc: {
+			id: docId,
+			field: docField,
+		},
+	}
+
+	const exportConfig = {
+		index: true,
+		doc: true,
+	}
+
+	// @ts-ignore
+	const index = new FlexSearch(indexConfig)
+
+	if (typeof window !== 'undefined' && window.Worker) {
+		const serializedIndex = await indexWorker.index({
+			values,
+			indexConfig,
+			exportConfig,
+		})
+
+		// @ts-ignore
+		index.import(serializedIndex, exportConfig)
+	} else {
+		// @ts-ignore
+		index.add(values)
+	}
+
+	return index
+}

--- a/src/components/Layout/ConstraintSection.jsx
+++ b/src/components/Layout/ConstraintSection.jsx
@@ -1,6 +1,5 @@
-import FlexSearch from 'flexsearch'
 import React, { useEffect, useRef } from 'react'
-import { indexWorker } from 'src/searchIndex'
+import { buildSearchIndex } from 'src/buildSearchIndex'
 
 import { ConstraintServiceContext, useMachineBus } from '../../machineBus'
 import { CheckboxPopup } from '../Constraints/CheckboxPopup'
@@ -79,41 +78,11 @@ const ConstraintBuilder = ({ constraintConfig, color }) => {
 	useEffect(() => {
 		const buildIndex = async () => {
 			if (type === 'select' && searchIndex.current === null && availableValues.length > 0) {
-				// The configuration *must* be the same for import and export
-				const indexConfig = {
-					encode: 'advanced',
-					tokenize: 'reverse',
-					suggest: true,
-					cache: true,
-					doc: {
-						id: 'item',
-						field: 'item',
-					},
-				}
-
-				const exportConfig = {
-					index: true,
-					doc: true,
-				}
-
-				// @ts-ignore
-				const index = new FlexSearch(indexConfig)
-
-				if (typeof window !== 'undefined' && window.Worker) {
-					const serializedIndex = await indexWorker.index({
-						values: availableValues,
-						indexConfig,
-						exportConfig,
-					})
-
-					// @ts-ignore
-					index.import(serializedIndex, exportConfig)
-				} else {
-					// @ts-ignore
-					index.add(availableValues)
-				}
-
-				searchIndex.current = index
+				searchIndex.current = await buildSearchIndex({
+					docId: 'item',
+					docField: 'item',
+					values: availableValues,
+				})
 			}
 		}
 


### PR DESCRIPTION
The classes select menu did not filter when queried, and would did not
update when the mine was changed. This PR fixes this by indexing
the available classes on first render and each time the mine changes.

Closes: #89

Squashed commits:
* Change available classes when the mine changes
* Rebuild search index when the mine changes
* Reset the query when the popup closes

