### PR TITLE
Display error states when the mine/class combo does not return results

### DIFF
--- a/src/components/Layout/ConstraintSection.jsx
+++ b/src/components/Layout/ConstraintSection.jsx
@@ -100,6 +100,10 @@ const ConstraintBuilder = ({ constraintConfig, color }) => {
 			break
 	}
 
+	if (state.matches('noConstraintItems') || state.matches('loading')) {
+		return null
+	}
+
 	return (
 		<ConstraintServiceContext.Provider value={{ state, send }}>
 			<Constraint constraintIconText={label} constraintName={name} labelBorderColor={color}>

--- a/src/components/Shared/NonIdealStates.jsx
+++ b/src/components/Shared/NonIdealStates.jsx
@@ -2,11 +2,12 @@ import { Classes, NonIdealState } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
 
-export const NonIdealStateWarning = ({ title = '', description = '' }) => (
+export const NonIdealStateWarning = ({ title = '', description = '', className = '' }) => (
 	<NonIdealState
 		title={title}
 		description={description}
 		icon={IconNames.WARNING_SIGN}
+		className={className}
 		css={{
 			paddingBottom: 32,
 			borderRadius: 3,

--- a/src/fetchSummary.js
+++ b/src/fetchSummary.js
@@ -19,7 +19,18 @@ export const fetchSummary = async ({ rootUrl, query, path }) => {
 	const service = getService(rootUrl)
 	const q = new imjs.Query(query, service)
 
-	const fullPath = formatConstraintPath({ classView: query.from, path })
+	let fullPath
+	try {
+		fullPath = formatConstraintPath({ classView: query.from, path })
+
+		// make sure the path exists
+		await service.makePath(fullPath)
+	} catch (e) {
+		const err = new Error()
+		err.message = `The mine at ${rootUrl} does not contain the path ${fullPath}`
+
+		throw err
+	}
 
 	return await q.summarize(fullPath)
 }


### PR DESCRIPTION
This PR addresses these two issues:

1)
Some mine/class combinations may return partial data or no results at all.
This is handled by displaying informational cards so the user is made
aware of this.

2)
Some mine/class combinations may not have one or more of the default
constraints. For now the unavailable constraints are just removed from
the view.

Closes: #91

Squashed commits:
* Disable constraints for unavailable constraints in mine/class
* Handle errors when constraint path is unavailable
* Inform the user when there are no gene lengths for the mine/class combo
* Inform the user when there is no table data for the mine/class combo
* Inform the user when there is no organism summary for the mine/class combo