### PR TITLE
Fix: the run query button should execute the new query

### DIFF
--- a/src/components/DataViz/BarChart.jsx
+++ b/src/components/DataViz/BarChart.jsx
@@ -12,7 +12,7 @@ import {
 	Tooltip,
 	XAxis,
 } from 'recharts'
-import { FETCH_INITIAL_SUMMARY } from 'src/actionConstants'
+import { FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/actionConstants'
 import { fetchSummary } from 'src/fetchSummary'
 import { blinkingSkeletonAnimation } from 'src/styleUtils'
 import { Machine } from 'xstate'
@@ -74,6 +74,7 @@ export const BarChartMachine = Machine(
 		on: {
 			// Making it global ensures that we retry when the mine or class changes
 			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
 		},
 		states: {
 			idle: {},

--- a/src/components/DataViz/PieChart.jsx
+++ b/src/components/DataViz/PieChart.jsx
@@ -11,7 +11,7 @@ import {
 	Text,
 	Tooltip,
 } from 'recharts'
-import { FETCH_INITIAL_SUMMARY } from 'src/actionConstants'
+import { FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/actionConstants'
 import { fetchSummary } from 'src/fetchSummary'
 import { blinkingSkeletonAnimation } from 'src/styleUtils'
 import { Machine } from 'xstate'
@@ -72,6 +72,7 @@ export const PieChartMachine = Machine(
 		on: {
 			// Making it global ensure we update the table when the mine/class changes
 			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
 		},
 		states: {
 			idle: {},

--- a/src/components/DataViz/Table.jsx
+++ b/src/components/DataViz/Table.jsx
@@ -13,7 +13,11 @@ import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
 import { assign } from '@xstate/immer'
 import React, { useState } from 'react'
-import { FETCH_INITIAL_SUMMARY, SET_AVAILABLE_COLUMNS } from 'src/actionConstants'
+import {
+	FETCH_INITIAL_SUMMARY,
+	FETCH_UPDATED_SUMMARY,
+	SET_AVAILABLE_COLUMNS,
+} from 'src/actionConstants'
 import { fetchTable } from 'src/fetchSummary'
 import { noop } from 'src/utils'
 import { humanize, titleize } from 'underscore.string'
@@ -149,6 +153,7 @@ export const TableChartMachine = Machine(
 		on: {
 			// Making it global ensure we update the table when the mine/class changes
 			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
 		},
 		states: {
 			idle: {},


### PR DESCRIPTION
This fixes a regression introduced earlier by removing `FETCH_UPDATED_SUMMARY`
from the action constants, by reapplying it.

Closes: #95
