### PR TITLE
Fix: the bar chart not updating when a new query was run

### DIFF
--- a/src/components/DataViz/BarChart.jsx
+++ b/src/components/DataViz/BarChart.jsx
@@ -123,9 +123,6 @@ export const BarChartMachine = Machine(
 					query = {
 						from: classView,
 						select: ['length', 'primaryIdentifier'],
-						model: {
-							name: 'genomic',
-						},
 						orderBy: [
 							{
 								path: 'length',
@@ -135,6 +132,7 @@ export const BarChartMachine = Machine(
 					}
 				}
 
+				query.model = { name: 'genomic' }
 				const summary = await fetchSummary({ rootUrl, query, path })
 
 				return {


### PR DESCRIPTION
There were xml validation errors that prevented the bar chart from
properly updating with new queries. By explicitly setting the model name,
the query can be validated.

Closes: #97

