### PR TITLE
Fix: searching in a Suggest constraint widget does not filter items

### DIFF
--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -190,7 +190,7 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 							nonIdealTitle="No items found"
 							nonIdealDescription="If you feel this is a mistake, try refreshing the browser. If that doesn't work, let us know"
 							// @ts-ignore
-							searchIndex={searchIndex.current}
+							searchIndex={searchIndex}
 						/>
 					</ConstraintCard>
 				</div>

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -62,7 +62,7 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 					nonIdealTitle="No items found"
 					nonIdealDescription="If you feel this is a mistake, try refreshing the browser. If that doesn't work, let us know"
 					// @ts-ignore
-					searchIndex={searchIndex.current}
+					searchIndex={searchIndex}
 				/>
 			</div>
 		</ConstraintServiceContext.Provider>

--- a/src/components/Widgets/SuggestWidget.jsx
+++ b/src/components/Widgets/SuggestWidget.jsx
@@ -115,12 +115,12 @@ export const SuggestWidget = ({
 	// the value directly to the added constraints list when clicked, so we reset the input here
 	const renderInputValue = () => ''
 	const filterQuery = (query, items) => {
-		if (query === '' || searchIndex === null) {
+		if (query === '' || searchIndex.current === null) {
 			return items.filter((i) => !selectedValues.includes(i.name))
 		}
 
 		// flexSearch's default result limit is set 1000, so we set it to the length of all items
-		const results = searchIndex.search(query, availableValues.length)
+		const results = searchIndex.current.search(query, availableValues.length)
 
 		return results
 	}


### PR DESCRIPTION
When searching for a constraint in an Suggest input widget, the items do
not get filtered. This happened because `searchIndex.current` was being
provided as a prop, and because the reference to `current` stayed
persistent, the component would not re-render.

Closes: #104 