### PR TITLE
Chore: create an overview machine with a config object

### DIFF
--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -10,7 +10,7 @@ import { ConstraintServiceContext, useMachineBus, useServiceContext } from 'src/
 import { PopupCard } from '../Shared/PopupCard'
 import { CheckboxWidget } from '../Widgets/CheckboxWidget'
 import { SuggestWidget } from '../Widgets/SuggestWidget'
-import { createConstraintMachine } from './createConstraintMachine'
+import { overviewConstraintMachine } from './overviewConstraintMachine'
 
 const ConstraintCard = ({ children }) => {
 	const [state, send] = useServiceContext('constraints')
@@ -118,7 +118,13 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
 	const [state, send] = useMachineBus(
-		createConstraintMachine({ id: type, path, op, constraintItemsQuery })
+		overviewConstraintMachine.withContext({
+			...overviewConstraintMachine.context,
+			op,
+			type,
+			constraintPath: path,
+			constraintItemsQuery,
+		})
 	)
 
 	const constraintCount = state.context.selectedValues.length

--- a/src/components/Overview/overviewConstraintMachine.js
+++ b/src/components/Overview/overviewConstraintMachine.js
@@ -16,25 +16,18 @@ import { sendToBus } from 'src/machineBus'
 import { formatConstraintPath } from 'src/utils'
 import { Machine } from 'xstate'
 
-/** @type {import('../../types').CreateConstraintMachine} */
-export const createConstraintMachine = ({
-	id,
-	initial = 'noConstraintsSet',
-	path = '',
-	op,
-	constraintItemsQuery,
-}) => {
-	/** @type {import('../../types').ConstraintMachineConfig} */
-	const config = {
-		id,
-		initial,
+export const overviewConstraintMachine = Machine(
+	{
+		id: 'constraint machine',
+		initial: 'noConstraintsSet',
 		context: {
-			type: id,
-			constraintPath: path,
+			type: '',
+			op: '',
+			constraintPath: '',
 			selectedValues: [],
 			availableValues: [],
 			classView: '',
-			constraintItemsQuery,
+			constraintItemsQuery: {},
 		},
 		on: {
 			[LOCK_ALL_CONSTRAINTS]: 'constraintLimitReached',
@@ -100,9 +93,8 @@ export const createConstraintMachine = ({
 				},
 			},
 		},
-	}
-
-	return Machine(config, {
+	},
+	{
 		actions: {
 			// @ts-ignore
 			logErrorToConsole: (_, event) => console.warn(event.data),
@@ -124,7 +116,7 @@ export const createConstraintMachine = ({
 				ctx.selectedValues = []
 			}),
 			applyOverviewConstraint: (ctx) => {
-				const { classView, constraintPath, selectedValues, availableValues } = ctx
+				const { classView, constraintPath, selectedValues, availableValues, op } = ctx
 
 				const query = {
 					op,
@@ -182,5 +174,5 @@ export const createConstraintMachine = ({
 				}
 			},
 		},
-	})
-}
+	}
+)


### PR DESCRIPTION
I previously had created a function to dynamically create overview
constraint machines. But this was a misguided premature abstraction, since
only the Overview component uses it. And xstate provides an idiomatic
way to pre-bind data to the context with the `machine.withContext` method.

This commit makes the overview machine a static configuration object, and
passes in each constraints required context data on creation from within
the component.

Closes: #106 