### PR TITLE
Perf: Use xstate's assign rather than immer

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -7,7 +7,7 @@ import React, { useEffect } from 'react'
 import { FETCH_INITIAL_SUMMARY, TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
 import { AppManagerServiceContext, sendToBus, useMachineBus } from 'src/machineBus'
 
-import { logo } from '../../images/logo.png'
+import logo from '../../images/logo.png'
 import { BarChart } from '../BarChart/BarChart'
 import { ConstraintSection } from '../ConstraintSection'
 import { NavigationBar } from '../Navigation/NavigationBar'

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -1,7 +1,17 @@
-import { assign } from '@xstate/immer'
 import { FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
 import { fetchSummary } from 'src/fetchSummary'
-import { Machine } from 'xstate'
+import { assign, Machine } from 'xstate'
+
+import { logErrorToConsole } from '../../utils'
+
+const setLengthSummary = assign({
+	// @ts-ignore
+	lengthStats: (_, { data }) => data.lengthStats,
+	// @ts-ignore
+	lengthSummary: (_, { data }) => data.lengthSummary,
+	// @ts-ignore
+	classView: (_, { data }) => data.classView,
+})
 
 export const BarChartMachine = Machine(
 	{
@@ -50,14 +60,8 @@ export const BarChartMachine = Machine(
 	},
 	{
 		actions: {
-			// @ts-ignore
-			setLengthSummary: assign((ctx, { data }) => {
-				ctx.lengthStats = data.lengthStats
-				ctx.lengthSummary = data.lengthSummary
-				ctx.classView = data.classView
-			}),
-			// @ts-ignore
-			logErrorToConsole: (ctx, event) => console.warn(event.data),
+			setLengthSummary,
+			logErrorToConsole,
 		},
 		guards: {
 			hasSummary: (ctx) => {

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -1,7 +1,13 @@
-import { assign } from '@xstate/immer'
 import { FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
 import { fetchSummary } from 'src/fetchSummary'
-import { Machine } from 'xstate'
+import { assign, Machine } from 'xstate'
+
+const setSummaryResults = assign({
+	// @ts-ignore
+	allClassOrganisms: (_, { data }) => data.summary,
+	// @ts-ignore
+	classView: (_, { data }) => data.classView,
+})
 
 export const PieChartMachine = Machine(
 	{
@@ -24,7 +30,7 @@ export const PieChartMachine = Machine(
 					src: 'fetchItems',
 					onDone: {
 						target: 'pending',
-						actions: 'setClassItems',
+						actions: 'setSummaryResults',
 					},
 					onError: {
 						target: 'idle',
@@ -43,11 +49,7 @@ export const PieChartMachine = Machine(
 	},
 	{
 		actions: {
-			// @ts-ignore
-			setClassItems: assign((ctx, { data }) => {
-				ctx.allClassOrganisms = data.summary
-				ctx.classView = data.classView
-			}),
+			setSummaryResults,
 		},
 		guards: {
 			hasSummary: (ctx) => ctx.allClassOrganisms.length > 0,

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -113,7 +113,7 @@ const CODES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 export const QueryController = () => {
 	const [state, send] = useMachineBus(queryControllerMachine)
 
-	const { currentConstraints, classView, selectedPaths, rootUrl, appView } = state.context
+	const { currentConstraints, classView, selectedPaths, rootUrl } = state.context
 
 	let color = 'var(--green5)'
 
@@ -165,7 +165,7 @@ export const QueryController = () => {
 
 	return (
 		<div css={{ paddingTop: 10, margin: '0 20px' }}>
-			{appView === 'defaultView' && <BrowserConstraintViewAll />}
+			<BrowserConstraintViewAll />
 			<RunQueryButton
 				intent={currentConstraints.length === 0 ? 'none' : 'success'}
 				isDisabled={currentConstraints.length === 0}

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -1,7 +1,5 @@
-import { assign } from '@xstate/immer'
 import {
 	APPLY_OVERVIEW_CONSTRAINT_TO_QUERY,
-	CHANGE_CONSTRAINT_VIEW,
 	DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY,
 	DELETE_QUERY_CONSTRAINT,
 	FETCH_INITIAL_SUMMARY,
@@ -9,7 +7,56 @@ import {
 	UNSET_CONSTRAINT,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/machineBus'
-import { Machine } from 'xstate'
+import { assign, Machine } from 'xstate'
+
+const initializeMachine = assign({
+	currentConstraints: () => [],
+	selectedPaths: () => [],
+	// @ts-ignore
+	classView: (_, { globalConfig }) => globalConfig.classView,
+	// @ts-ignore
+	rootUrl: (_, { globalConfig }) => globalConfig.rootUrl,
+})
+
+const addConstraint = assign({
+	// @ts-ignore
+	currentConstraints: (ctx, { query }) => {
+		const withQueryRemoved = ctx.currentConstraints.filter((c) => {
+			return c.path !== query.path
+		})
+
+		withQueryRemoved.push(query)
+
+		return withQueryRemoved
+	},
+})
+
+const removeConstraint = assign({
+	// @ts-ignore
+	currentConstraints: (ctx, { type, path }) => {
+		const prevCount = ctx.currentConstraints.length
+		const withoutQuery = ctx.currentConstraints.filter((c) => {
+			return c.path !== path
+		})
+
+		const nextCount = withoutQuery.length
+
+		// The constraint is being deleted internally, and needs to be synced
+		// with the constraint machines
+		if (type !== DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY && nextCount !== prevCount) {
+			const constraintPath = path.slice(path.indexOf('.') + 1)
+
+			sendToBus({ type: UNSET_CONSTRAINT, path: constraintPath })
+		}
+
+		return withoutQuery
+	},
+})
+
+const setSelectedPaths = assign({
+	// @ts-ignore
+	selectedPaths: (_, { selectedPaths }) => selectedPaths,
+})
 
 /**
  *
@@ -20,13 +67,12 @@ export const queryControllerMachine = Machine(
 		initial: 'idle',
 		context: {
 			currentConstraints: [],
-			appView: 'defaultView',
 			classView: '',
 			selectedPaths: [],
 			rootUrl: '',
 		},
 		on: {
-			[SET_AVAILABLE_COLUMNS]: { actions: 'setSelectPaths' },
+			[SET_AVAILABLE_COLUMNS]: { actions: 'setSelectedPaths' },
 			[DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY]: { target: 'idle', actions: 'removeConstraint' },
 			[FETCH_INITIAL_SUMMARY]: {
 				target: 'idle',
@@ -37,7 +83,6 @@ export const queryControllerMachine = Machine(
 			idle: {
 				on: {
 					[DELETE_QUERY_CONSTRAINT]: { actions: 'removeConstraint' },
-					[CHANGE_CONSTRAINT_VIEW]: { actions: 'setAppView' },
 					[APPLY_OVERVIEW_CONSTRAINT_TO_QUERY]: [
 						{
 							target: 'constraintLimitReached',
@@ -64,47 +109,10 @@ export const queryControllerMachine = Machine(
 	},
 	{
 		actions: {
-			// @ts-ignore
-			setAppView: assign((ctx, { newTabId }) => {
-				ctx.appView = newTabId
-			}),
-			// @ts-ignore
-			initializeMachine: assign((ctx, { globalConfig }) => {
-				ctx.currentConstraints = []
-				ctx.selectedPaths = []
-				ctx.classView = globalConfig.classView
-				ctx.rootUrl = globalConfig.rootUrl
-			}),
-			// @ts-ignore
-			addConstraint: assign((ctx, { query }) => {
-				const withQueryRemoved = ctx.currentConstraints.filter((c) => {
-					return c.path !== query.path
-				})
-
-				withQueryRemoved.push(query)
-				ctx.currentConstraints = withQueryRemoved
-			}),
-			// @ts-ignore
-			removeConstraint: assign((ctx, { type, path }) => {
-				const prevCount = ctx.currentConstraints.length
-				ctx.currentConstraints = ctx.currentConstraints.filter((c) => {
-					return c.path !== path
-				})
-
-				const nextCount = ctx.currentConstraints.length
-
-				// The constraint is being deleted internally, and needs to be synced
-				// with the constraint machines
-				if (type !== DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY && nextCount !== prevCount) {
-					const constraintPath = path.slice(path.indexOf('.') + 1)
-
-					sendToBus({ type: UNSET_CONSTRAINT, path: constraintPath })
-				}
-			}),
-			// @ts-ignore
-			setSelectPaths: assign((ctx, { selectedPaths }) => {
-				ctx.selectedPaths = selectedPaths
-			}),
+			initializeMachine,
+			addConstraint,
+			removeConstraint,
+			setSelectedPaths,
 		},
 		guards: {
 			canAddConstraint: (context, _, { cond }) => {

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -1,33 +1,38 @@
-import { assign } from '@xstate/immer'
 import {
 	ADD_TEMPLATE_CONSTRAINT,
 	FETCH_UPDATED_SUMMARY,
 	TEMPLATE_CONSTRAINT_UPDATED,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/machineBus'
-import { Machine } from 'xstate'
+import { assign, Machine } from 'xstate'
 
 /**
  *
  */
-// @ts-ignore
-const setQueries = assign((ctx, { path, selectedValues }) => {
-	const query = ctx.template.where.find((con) => con.path === path)
-	if ('value' in query) {
-		query.value = selectedValues[0]
-	} else {
-		query.values = selectedValues
-	}
+const setQueries = assign({
+	// @ts-ignore
+	template: (ctx, { path, selectedValues }) => {
+		const updatedQuery = { ...ctx.template, where: [...ctx.template.where] }
 
-	sendToBus({ type: TEMPLATE_CONSTRAINT_UPDATED, path })
+		const query = updatedQuery.where.find((con) => con.path === path)
+		if ('value' in query) {
+			query.value = selectedValues[0]
+		} else {
+			query.values = selectedValues
+		}
+
+		sendToBus({ type: TEMPLATE_CONSTRAINT_UPDATED, path })
+
+		return updatedQuery
+	},
 })
 
 /**
  *
  */
-// @ts-ignore
-const setActiveQuery = assign((ctx, { query }) => {
-	ctx.isActiveQuery = query.name === ctx.template.name
+const setActiveQuery = assign({
+	// @ts-ignore
+	isActiveQuery: (ctx, { query }) => query.name === ctx.template.name,
 })
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,3 +21,5 @@ export const getTagCategories = (tags) => {
 
 	return categories.length > 0 ? categories : ['Misc']
 }
+
+export const logErrorToConsole = (_, event) => console.warn(event.data)


### PR DESCRIPTION
`@xstate/immer` provides a nicer DX for updating the context. But it
fails miserably with large datasets. This is because it needs to
recursively convert each item into an immutable draft. Considering that
intermine produces enormous amounts of data, and we don't modify that
data, we will not have an issue with mutations there.

The only place where mutation would cause problems is with our data
structures for state management. This is alleviated by using `xstate`'s
assign method.

Therefore, for performance reasons, this PR refactors to using
`xstate`s assign.

Closes: #108 