### PR TITLE
Enable filtering queries with list constraints

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -9,7 +9,7 @@ import { AppManagerServiceContext, sendToBus, useMachineBus } from 'src/machineB
 
 import logo from '../../images/logo.png'
 import { BarChart } from '../BarChart/BarChart'
-import { ConstraintSection } from '../ConstraintSection'
+import { ConstraintSection } from '../ConstraintSection/ConstraintSection'
 import { NavigationBar } from '../Navigation/NavigationBar'
 import { PieChart } from '../PieChart/PieChart'
 import { Table } from '../Table/Table'

--- a/src/components/ConstraintSection/constraintSectionMachine.jsx
+++ b/src/components/ConstraintSection/constraintSectionMachine.jsx
@@ -1,0 +1,40 @@
+import { ADD_LIST_TAG, REMOVE_LIST_TAG } from 'src/eventConstants'
+import { assign, Machine } from 'xstate'
+
+const addListTag = assign({
+	// @ts-ignore
+	listNames: (ctx, { listName }) => {
+		return [...ctx.listNames, listName]
+	},
+})
+
+const removeListTag = assign({
+	// @ts-ignore
+	listNames: (ctx, { listName }) => {
+		return ctx.listNames.filter((list) => list !== listName)
+	},
+})
+
+export const constraintSectionMachine = Machine(
+	{
+		id: 'ConstraintSection',
+		initial: 'idle',
+		context: {
+			listNames: [],
+		},
+		states: {
+			idle: {
+				on: {
+					[REMOVE_LIST_TAG]: { actions: 'removeListTag' },
+					[ADD_LIST_TAG]: { actions: 'addListTag' },
+				},
+			},
+		},
+	},
+	{
+		actions: {
+			addListTag,
+			removeListTag,
+		},
+	}
+)

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -14,7 +14,7 @@ const AuthenticatedIcon = (isAuthenticated) => (
 	/>
 )
 
-export const Mine = () => {
+export const MineSelector = () => {
 	const [isAuthenticated, setAuthentication] = useState(false)
 	const [state, send] = useServiceContext('appManager')
 

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -1,138 +1,33 @@
-import { Button, ButtonGroup, Menu, MenuItem, Navbar } from '@blueprintjs/core'
-import { IconNames } from '@blueprintjs/icons'
-import { Select } from '@blueprintjs/select'
-import React, { useEffect, useRef, useState } from 'react'
-import { buildSearchIndex } from 'src/buildSearchIndex'
+import { Navbar } from '@blueprintjs/core'
+import React from 'react'
 import { CHANGE_CLASS } from 'src/eventConstants'
 import { useServiceContext } from 'src/machineBus'
-import { pluralizeFilteredCount } from 'src/utils'
 
-import { NumberedSelectMenuItems } from '../Shared/Selects'
-import { Mine } from './MineSelect'
-
-/**
- *
- */
-const renderMenu = ({ filteredItems, itemsParentRef, query, renderItem }) => {
-	const renderedItems = filteredItems.map(renderItem)
-	const infoText = pluralizeFilteredCount(filteredItems, query)
-
-	return (
-		<Menu ulRef={itemsParentRef}>
-			<MenuItem disabled={true} text={infoText} />
-			{renderedItems}
-		</Menu>
-	)
-}
+import { ClassSelector } from './ClassSelector'
+import { ListSelector } from './ListSelector'
+import { MineSelector } from './MineSelector'
 
 /**
  *
  */
 export const NavigationBar = () => {
-	const [selectedTheme, changeTheme] = useState('light')
-	const isLightTheme = selectedTheme === 'light'
-
 	const [state, send] = useServiceContext('appManager')
-	const { classView, modelClasses } = state.context
-	const classSearchIndex = useRef(null)
-
-	const classDisplayName =
-		modelClasses.find((model) => model.name === classView)?.displayName ?? 'Gene'
-
-	useEffect(() => {
-		const indexClasses = async () => {
-			if (modelClasses.length > 0) {
-				classSearchIndex.current = await buildSearchIndex({
-					docId: 'name',
-					docField: 'displayName',
-					values: modelClasses,
-				})
-			}
-		}
-
-		indexClasses()
-	}, [modelClasses])
+	const { classView, modelClasses, listsForCurrentClass } = state.context
 
 	const handleClassSelect = ({ name }) => {
 		send({ type: CHANGE_CLASS, newClass: name })
 	}
 
-	const filterQuery = (query, items) => {
-		if (query === '' || !classSearchIndex?.current) {
-			return items
-		}
-
-		// flexSearch's default result limit is set 1000, so we set it to the length of all items
-		return classSearchIndex.current.search(query, modelClasses.length)
-	}
-
 	return (
 		<Navbar css={{ padding: '0 40px' }}>
-			<Navbar.Group css={{ width: '100%' }}>
-				<Mine />
-				{/* 
-						Selected Class view
-				  */}
-				<div css={{ display: 'flex', marginLeft: 'auto', marginRight: 20 }}>
-					<span
-						// @ts-ignore
-						css={{
-							fontSize: 'var(--fs-desktopM2)',
-							fontWeight: 'var(--fw-regular)',
-							marginRight: 8,
-							marginBottom: 0,
-						}}
-					>
-						{classDisplayName}
-					</span>
-					<Select
-						items={state.context.modelClasses}
-						filterable={true}
-						itemRenderer={NumberedSelectMenuItems}
-						onItemSelect={handleClassSelect}
-						itemListRenderer={renderMenu}
-						itemListPredicate={filterQuery}
-						resetOnClose={true}
-					>
-						<Button
-							aria-label="select the views you'd like to query"
-							// used to override `Blueprintjs` styles for a small button
-							small={true}
-							text="change view"
-							alignText="left"
-							rightIcon={IconNames.CARET_DOWN}
-						/>
-					</Select>
-				</div>
-				{/* 
-						Theme controls
-				 */}
-				<ButtonGroup css={{ marginLeft: 'auto' }}>
-					<Button
-						active={isLightTheme}
-						intent={isLightTheme ? 'primary' : 'none'}
-						icon={IconNames.FLASH}
-						onClick={() => changeTheme('light')}
-					/>
-					<Button
-						active={!isLightTheme}
-						intent={isLightTheme ? 'none' : 'primary'}
-						icon={IconNames.MOON}
-						onClick={() => changeTheme('dark')}
-					/>
-				</ButtonGroup>
-				{/* 
-						Reset all button
-				 */}
-				<Button
-					css={{
-						marginLeft: 'auto',
-						minWidth: 80,
-					}}
-					text="Reset"
-					intent="danger"
-					icon={IconNames.ERROR}
+			<Navbar.Group css={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+				<MineSelector />
+				<ClassSelector
+					handleClassSelect={handleClassSelect}
+					modelClasses={modelClasses}
+					classView={classView}
 				/>
+				<ListSelector listsForCurrentClass={listsForCurrentClass} />
 			</Navbar.Group>
 		</Navbar>
 	)

--- a/src/components/Shared/InfoIconPopover.jsx
+++ b/src/components/Shared/InfoIconPopover.jsx
@@ -1,0 +1,21 @@
+import { H4, Icon, Popover, PopoverInteractionKind, Text } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+import React from 'react'
+
+export const InfoIconPopover = ({ description, position = 'auto', title }) => (
+	<Popover
+		interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+		boundary="viewport"
+		css={{ marginRight: 20, marginLeft: 5 }}
+		usePortal={true}
+		lazy={true}
+		// @ts-ignore
+		position={position}
+	>
+		<Icon icon={IconNames.INFO_SIGN} color="var(--grey4)" iconSize={20} />
+		<div css={{ maxWidth: 500, padding: 20 }}>
+			{title && <H4>{title}</H4>}
+			<Text>{description ? description : 'No Description Provided'}</Text>
+		</div>
+	</Popover>
+)

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -1,6 +1,8 @@
 import {
+	ADD_LIST_CONSTRAINT,
 	ADD_TEMPLATE_CONSTRAINT,
 	FETCH_UPDATED_SUMMARY,
+	REMOVE_LIST_CONSTRAINT,
 	TEMPLATE_CONSTRAINT_UPDATED,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/machineBus'
@@ -36,6 +38,22 @@ const setActiveQuery = assign({
 })
 
 /**
+ *
+ */
+const addListConstraint = assign({
+	// @ts-ignore
+	listNames: (ctx, { listName }) => [...ctx.listNames, listName],
+})
+
+/**
+ *
+ */
+const removeListConstraint = assign({
+	// @ts-ignore
+	listNames: (ctx, { listName }) => ctx.listNames.filter((list) => list !== listName),
+})
+
+/**
  * @returns {boolean}
  */
 const templateHasQuery = (ctx, { path }) => {
@@ -52,12 +70,15 @@ export const templateQueryMachine = Machine(
 		context: {
 			template: null,
 			isActiveQuery: false,
+			listNames: [],
 		},
 		states: {
 			idle: {
 				on: {
 					[ADD_TEMPLATE_CONSTRAINT]: { actions: 'setQueries', cond: 'templateHasQuery' },
 					[FETCH_UPDATED_SUMMARY]: { actions: 'setActiveQuery' },
+					[ADD_LIST_CONSTRAINT]: { actions: 'addListConstraint' },
+					[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
 				},
 			},
 		},
@@ -66,6 +87,8 @@ export const templateQueryMachine = Machine(
 		actions: {
 			setQueries,
 			setActiveQuery,
+			addListConstraint,
+			removeListConstraint,
 		},
 		guards: {
 			// @ts-ignore

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,0 +1,7 @@
+export const listConstraintQuery = {
+	path: '',
+	op: 'IN',
+	values: [],
+}
+
+export const CODES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -43,6 +43,8 @@ export const CHANGE_CLASS = 'appManager/class/change'
 export const CHANGE_CONSTRAINT_VIEW = 'appManager/view/change'
 export const TOGGLE_CATEGORY_VISIBILITY = 'appManager/category/visibility'
 export const TOGGLE_VIEW_IS_LOADING = 'appManager/view/isLoading'
+export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
+export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 
 /**
  * Table
@@ -50,3 +52,9 @@ export const TOGGLE_VIEW_IS_LOADING = 'appManager/view/isLoading'
 export const CHANGE_PAGE = 'table/page/change'
 
 export const UPDATE_TEMPLATE_QUERIES = 'templateView/templates/update'
+
+/**
+ * Constraint Section
+ */
+export const ADD_LIST_TAG = 'constraintSection/listTag/add'
+export const REMOVE_LIST_TAG = 'constraintSection/listTag/remove'

--- a/src/fetchSummary.js
+++ b/src/fetchSummary.js
@@ -71,3 +71,9 @@ export const fetchPathValues = async ({ path, rootUrl }) => {
 
 	return await service.pathValues(path)
 }
+
+export const fetchLists = async (rootUrl) => {
+	const service = getService(rootUrl)
+
+	return await service.fetchLists()
+}


### PR DESCRIPTION
This PR adds the ability to filter queries to the selected lists.
They can be selected from a filterable dropdown that also displays an
info button. This info button shows the description for the list when
hovering over it.

The selected lists are shown in different locations depending on the
query view:

1. overview constraints: shown alongside any other applied queries.
2. template constraints: shown above the category selection as tags

Users can also deselect lists from those locations.

Closes: #110 