### PR TITLE
Persist machines between component mounts

### DIFF
--- a/src/components/App/appManagerMachine.js
+++ b/src/components/App/appManagerMachine.js
@@ -79,9 +79,18 @@ const toggleViewIsLoading = assign({
 
 const updateTemplateQueries = assign({
 	// @ts-ignore
-	possibleQueries: (_, { queries }) => queries,
+	possibleQueries: (_, { templatesForSelectedCategories }) => templatesForSelectedCategories,
 	// @ts-ignore
 	categories: (_, { categories }) => categories,
+	// @ts-ignore
+	templates: (_, { templates }) => templates,
+	// @ts-ignore
+	templatesForClassView: (_, { templatesForClassView }) => templatesForClassView,
+	// @ts-ignore
+	templatesByCategory: (_, { templatesByCategory }) => templatesByCategory,
+	// @ts-ignore
+	templatesForSelectedCategories: (_, { templatesForSelectedCategories }) =>
+		templatesForSelectedCategories,
 })
 
 const setTemplateView = assign({
@@ -148,7 +157,7 @@ const filterListsForClass = assign({
 
 export const appManagerMachine = Machine(
 	{
-		id: 'AppManager',
+		id: 'App Manager',
 		initial: 'loading',
 		context: {
 			appView: 'defaultView',
@@ -164,7 +173,6 @@ export const appManagerMachine = Machine(
 			},
 			showAllLabel: 'Show All',
 			possibleQueries: defaultQueries,
-			categories: {},
 			viewIsLoading: false,
 			selectedMine: {
 				name: isProduction ? 'HumanMine' : 'biotestmine',
@@ -172,6 +180,14 @@ export const appManagerMachine = Machine(
 					? 'https://www.humanmine.org/humanmine'
 					: 'http://localhost:9999/biotestmine',
 			},
+			// We have to keep the template context here because it is an invoked machine and clears its
+			// context when the state in which it was invoked is exited. Therefore we have to pass the previous
+			// context to the template machine to rehydrate it.
+			templates: Object.create(null),
+			templatesForClassView: [],
+			templatesByCategory: [],
+			templatesForSelectedCategories: [],
+			categories: Object.create(null),
 		},
 		on: {
 			[CHANGE_MINE]: { target: 'loading', actions: 'changeMine' },
@@ -219,8 +235,11 @@ export const appManagerMachine = Machine(
 					id: 'templateView',
 					src: templateViewMachine,
 					data: {
-						// Hack until xstate v5 introduces shallow merging
-						...templateViewMachine.context,
+						templates: (ctx) => ctx.templates,
+						templatesForClassView: (ctx) => ctx.templatesForClassView,
+						templatesByCategory: (ctx) => ctx.templatesByCategory,
+						templatesForSelectedCategories: (ctx) => ctx.templatesForSelectedCategories,
+						categories: (ctx) => ctx.categories,
 						classView: (ctx) => ctx.classView,
 						showAllLabel: (ctx) => ctx.showAllLabel,
 						rootUrl: (ctx) => ctx.selectedMine.rootUrl,

--- a/src/components/App/templateViewMachine.js
+++ b/src/components/App/templateViewMachine.js
@@ -16,6 +16,10 @@ const updateParent = sendParent((ctx) => ({
 	type: UPDATE_TEMPLATE_QUERIES,
 	queries: ctx.templatesForSelectedCategories,
 	categories: ctx.categories,
+	templates: ctx.templates,
+	templatesForClassView: ctx.templatesForClassView,
+	templatesByCategory: ctx.templatesByCategory,
+	templatesForSelectedCategories: ctx.templatesForSelectedCategories,
 }))
 
 /**
@@ -167,8 +171,18 @@ export const templateViewMachine = Machine(
 			showAllLabel: '',
 			rootUrl: '',
 		},
-		initial: 'loadTemplates',
+		initial: 'init',
 		states: {
+			init: {
+				always: [
+					{
+						target: 'allCategories',
+						cond: 'hasTemplates',
+						actions: ['updateParent'],
+					},
+					{ target: 'loadTemplates' },
+				],
+			},
 			allCategories: {
 				on: {
 					[CHANGE_CLASS]: {
@@ -198,7 +212,7 @@ export const templateViewMachine = Machine(
 					],
 				},
 			},
-			noTemplates: {},
+			errorFetchingTemplates: {},
 			loadTemplates: {
 				entry: 'sendIsLoading',
 				invoke: {
@@ -217,7 +231,7 @@ export const templateViewMachine = Machine(
 						],
 					},
 					onError: {
-						target: 'noTemplates',
+						target: 'errorFetchingTemplates',
 						actions: (ctx, event) =>
 							console.error('FETCH: could not fetch templates', { ctx, event }),
 					},
@@ -244,6 +258,10 @@ export const templateViewMachine = Machine(
 			// @ts-ignore
 			showAllClicked: (ctx, { tagName }) => {
 				return tagName === ctx.showAllLabel
+			},
+			// @ts-ignore
+			hasTemplates: (ctx) => {
+				return Object.keys(ctx.templates).length > 0
 			},
 		},
 		services: {

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -11,6 +11,8 @@ const setLengthSummary = assign({
 	lengthSummary: (_, { data }) => data.lengthSummary,
 	// @ts-ignore
 	classView: (_, { data }) => data.classView,
+	// @ts-ignore
+	rootUrl: (_, { data }) => data.rootUrl,
 })
 
 export const BarChartMachine = Machine(
@@ -28,10 +30,11 @@ export const BarChartMachine = Machine(
 			},
 			lengthSummary: [],
 			classView: '',
+			rootUrl: '',
 		},
 		on: {
 			// Making it global ensures that we retry when the mine or class changes
-			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+			[FETCH_INITIAL_SUMMARY]: { target: 'loading', cond: 'isInitialFetch' },
 			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
 		},
 		states: {
@@ -67,6 +70,13 @@ export const BarChartMachine = Machine(
 			hasSummary: (ctx) => {
 				return ctx.lengthSummary.length > 0
 			},
+			isInitialFetch: (ctx, { globalConfig }) => {
+				return (
+					ctx.lengthSummary.length === 0 ||
+					ctx.classView !== globalConfig.classView ||
+					ctx.rootUrl !== globalConfig.rootUrl
+				)
+			},
 		},
 		services: {
 			fetchGeneLength: async (_ctx, { globalConfig: { classView, rootUrl }, query: nextQuery }) => {
@@ -89,6 +99,7 @@ export const BarChartMachine = Machine(
 
 				return {
 					classView,
+					rootUrl,
 					lengthStats: summary.stats,
 					lengthSummary: summary.results.slice(0, summary.results.length - 1),
 				}

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -118,8 +118,8 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
 	const [state, send] = useMachineBus(
-		overviewConstraintMachine.withContext({
-			...overviewConstraintMachine.context,
+		overviewConstraintMachine(`ConstraintMachine-${name}`).withContext({
+			...overviewConstraintMachine().context,
 			op,
 			type,
 			constraintPath: path,

--- a/src/components/Overview/overviewConstraintMachine.js
+++ b/src/components/Overview/overviewConstraintMachine.js
@@ -33,9 +33,17 @@ const removeAll = assign({
 
 const setAvailableValues = assign({
 	// @ts-ignore
-	availableValues: (_, { data }) => data.items,
+	availableValues: (_, { data }) => {
+		return data.items
+	},
 	// @ts-ignore
-	classView: (_, { data }) => data.classView,
+	classView: (_, { data }) => {
+		return data.classView
+	},
+	// @ts-ignore
+	rootUrl: (_, { data }) => {
+		return data.rootUrl
+	},
 	selectedValues: () => [],
 })
 
@@ -63,129 +71,131 @@ const resetConstraint = ({ classView, constraintPath }) => {
 	})
 }
 
-export const overviewConstraintMachine = Machine(
-	{
-		id: 'constraint machine',
-		initial: 'noConstraintsSet',
-		context: {
-			type: '',
-			op: '',
-			constraintPath: '',
-			selectedValues: [],
-			availableValues: [],
-			classView: '',
-			constraintItemsQuery: {},
-		},
-		on: {
-			[LOCK_ALL_CONSTRAINTS]: 'constraintLimitReached',
-			[RESET_ALL_CONSTRAINTS]: { target: 'noConstraintsSet', actions: 'removeAll' },
-			[RESET_LOCAL_CONSTRAINT]: { target: 'noConstraintsSet', actions: 'removeAll' },
-			[UNSET_CONSTRAINT]: { target: 'constraintsUpdated', cond: 'pathMatches' },
-			// make a global action listener since we don't store them in local storage, and need
-			// to fetch them even if the rest of the state is rehydrated.
-			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
-		},
-		states: {
-			loading: {
-				invoke: {
-					id: 'fetchInitialValues',
-					src: 'fetchInitialValues',
-					onDone: {
-						target: 'noConstraintsSet',
-						actions: 'setAvailableValues',
+export const overviewConstraintMachine = (id = 'ConstraintMachine') =>
+	Machine(
+		{
+			id,
+			initial: 'noConstraintsSet',
+			context: {
+				type: '',
+				op: '',
+				constraintPath: '',
+				selectedValues: [],
+				availableValues: [],
+				classView: '',
+				rootUrl: '',
+				constraintItemsQuery: {},
+			},
+			on: {
+				[LOCK_ALL_CONSTRAINTS]: 'constraintLimitReached',
+				[RESET_ALL_CONSTRAINTS]: { target: 'noConstraintsSet', actions: 'removeAll' },
+				[RESET_LOCAL_CONSTRAINT]: { target: 'noConstraintsSet', actions: 'removeAll' },
+				[UNSET_CONSTRAINT]: { target: 'constraintsUpdated', cond: 'pathMatches' },
+				[FETCH_INITIAL_SUMMARY]: { target: 'loading', cond: 'isInitialFetch' },
+			},
+			states: {
+				loading: {
+					invoke: {
+						id: 'fetchInitialValues',
+						src: 'fetchInitialValues',
+						onDone: {
+							target: 'noConstraintsSet',
+							actions: 'setAvailableValues',
+						},
+						onError: {
+							target: 'noConstraintItems',
+							actions: 'logErrorToConsole',
+						},
 					},
-					onError: {
-						target: 'noConstraintItems',
-						actions: 'logErrorToConsole',
+				},
+				noConstraintItems: {},
+				noConstraintsSet: {
+					always: [{ target: 'noConstraintItems', cond: 'hasNoConstraintItems' }],
+					entry: 'resetConstraint',
+					on: {
+						[ADD_CONSTRAINT]: {
+							target: 'constraintsUpdated',
+							actions: 'addConstraint',
+						},
+					},
+				},
+				constraintsUpdated: {
+					always: [{ target: 'noConstraintsSet', cond: 'selectedListIsEmpty' }],
+					on: {
+						[ADD_CONSTRAINT]: { actions: 'addConstraint' },
+						[REMOVE_CONSTRAINT]: { actions: 'removeConstraint' },
+						[APPLY_DATA_BROWSER_CONSTRAINT]: {
+							target: 'constraintsApplied',
+							actions: 'applyOverviewConstraint',
+						},
+					},
+				},
+				constraintsApplied: {
+					on: {
+						[ADD_CONSTRAINT]: {
+							target: 'constraintsUpdated',
+							actions: 'addConstraint',
+						},
+						[REMOVE_CONSTRAINT]: {
+							target: 'constraintsUpdated',
+							actions: 'removeConstraint',
+						},
+					},
+				},
+				constraintLimitReached: {
+					on: {
+						[REMOVE_CONSTRAINT]: { actions: 'removeConstraint' },
 					},
 				},
 			},
-			noConstraintItems: {},
-			noConstraintsSet: {
-				always: [{ target: 'noConstraintItems', cond: 'hasNoConstraintItems' }],
-				entry: 'resetConstraint',
-				on: {
-					[ADD_CONSTRAINT]: {
-						target: 'constraintsUpdated',
-						actions: 'addConstraint',
-					},
-				},
-			},
-			constraintsUpdated: {
-				always: [{ target: 'noConstraintsSet', cond: 'selectedListIsEmpty' }],
-				on: {
-					[ADD_CONSTRAINT]: { actions: 'addConstraint' },
-					[REMOVE_CONSTRAINT]: { actions: 'removeConstraint' },
-					[APPLY_DATA_BROWSER_CONSTRAINT]: {
-						target: 'constraintsApplied',
-						actions: 'applyOverviewConstraint',
-					},
-				},
-			},
-			constraintsApplied: {
-				on: {
-					[ADD_CONSTRAINT]: {
-						target: 'constraintsUpdated',
-						actions: 'addConstraint',
-					},
-					[REMOVE_CONSTRAINT]: {
-						target: 'constraintsUpdated',
-						actions: 'removeConstraint',
-					},
-				},
-			},
-			constraintLimitReached: {
-				on: {
-					[REMOVE_CONSTRAINT]: { actions: 'removeConstraint' },
-				},
-			},
 		},
-	},
-	{
-		actions: {
-			logErrorToConsole,
-			addConstraint,
-			removeConstraint,
-			removeAll,
-			setAvailableValues,
-			applyOverviewConstraint,
-			resetConstraint,
-		},
-		guards: {
-			selectedListIsEmpty: (ctx) => {
-				return ctx.selectedValues.length === 0
+		{
+			actions: {
+				logErrorToConsole,
+				addConstraint,
+				removeConstraint,
+				removeAll,
+				setAvailableValues,
+				applyOverviewConstraint,
+				resetConstraint,
 			},
-			hasNoConstraintItems: (ctx) => {
-				return ctx.availableValues.length === 0
+			guards: {
+				selectedListIsEmpty: (ctx) => {
+					return ctx.selectedValues.length === 0
+				},
+				hasNoConstraintItems: (ctx) => {
+					return ctx.availableValues.length === 0
+				},
+				// @ts-ignore
+				pathMatches: (ctx, { path }) => {
+					return ctx.constraintPath === path
+				},
+				// @ts-ignore
+				isInitialFetch: (ctx, { globalConfig }) => {
+					return ctx.rootUrl !== globalConfig.rootUrl || ctx.classView !== globalConfig.classView
+				},
 			},
-			// @ts-ignore
-			pathMatches: (ctx, { path }) => {
-				return ctx.constraintPath === path
-			},
-			hasNotInitialized: (ctx) => {
-				return ctx.availableValues.length === 0
-			},
-		},
-		services: {
-			fetchInitialValues: async (ctx, event) => {
-				const { constraintItemsQuery, constraintPath } = ctx
+			services: {
+				fetchInitialValues: async (ctx, event) => {
+					const { constraintItemsQuery, constraintPath } = ctx
 
-				const {
-					globalConfig: { rootUrl, classView },
-				} = event
+					const {
+						globalConfig: { rootUrl, classView },
+					} = event
 
-				const query = {
-					...constraintItemsQuery,
-					from: classView,
-				}
+					const query = {
+						...constraintItemsQuery,
+						from: classView,
+					}
 
-				const summary = await fetchSummary({ rootUrl, query, path: constraintPath })
+					const summary = await fetchSummary({ rootUrl, query, path: constraintPath })
 
-				return {
-					classView,
-					items: summary.results,
-				}
+					return {
+						rootUrl,
+						classView,
+						items: summary.results,
+					}
+				},
 			},
-		},
-	}
-)
+		}
+	)

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -7,6 +7,8 @@ const setSummaryResults = assign({
 	allClassOrganisms: (_, { data }) => data.summary,
 	// @ts-ignore
 	classView: (_, { data }) => data.classView,
+	// @ts-ignore
+	rootUrl: (_, { data }) => data.rootUrl,
 })
 
 export const PieChartMachine = Machine(
@@ -16,10 +18,11 @@ export const PieChartMachine = Machine(
 		context: {
 			allClassOrganisms: [],
 			classView: '',
+			rootUrl: '',
 		},
 		on: {
 			// Making it global ensure we update the table when the mine/class changes
-			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+			[FETCH_INITIAL_SUMMARY]: { target: 'loading', cond: 'isInitialFetch' },
 			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
 		},
 		states: {
@@ -53,6 +56,11 @@ export const PieChartMachine = Machine(
 		},
 		guards: {
 			hasSummary: (ctx) => ctx.allClassOrganisms.length > 0,
+			// @ts-ignore
+			isInitialFetch: (ctx, { globalConfig }) =>
+				ctx.allClassOrganisms.length === 0 ||
+				ctx.classView !== globalConfig.classView ||
+				ctx.rootUrl !== globalConfig.rootUrl,
 		},
 		services: {
 			fetchItems: async (_ctx, event) => {
@@ -74,6 +82,7 @@ export const PieChartMachine = Machine(
 
 				return {
 					classView,
+					rootUrl,
 					summary: summary.results,
 				}
 			},

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -107,6 +107,7 @@ export const queryControllerMachine = Machine(
 			[FETCH_INITIAL_SUMMARY]: {
 				target: 'idle',
 				actions: 'initializeMachine',
+				cond: 'isInitialFetch',
 			},
 		},
 		states: {
@@ -171,6 +172,10 @@ export const queryControllerMachine = Machine(
 			listOccupiesLastSlot: (context, _, { cond }) => {
 				// @ts-ignore
 				return context.currentConstraints.length + 1 === cond.maxConstraints
+			},
+			// @ts-ignore
+			isInitialFetch: (ctx, { globalConfig }) => {
+				return ctx.classView !== globalConfig.classView || ctx.rootUrl !== globalConfig.rootUrl
 			},
 		},
 	}

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -15,8 +15,10 @@ import { templateConstraintMachine } from './templateConstraintMachine'
 import { templateQueryMachine } from './templateQueryMachine'
 
 const ConstraintWidget = ({ constraint, rootUrl }) => {
+	const name = constraint.path.split('.').join(' > ')
+
 	const [state, send] = useMachineBus(
-		templateConstraintMachine.withContext({
+		templateConstraintMachine(`Template-${name} constraint widget`).withContext({
 			rootUrl,
 			path: constraint.path,
 			op: constraint.op,
@@ -27,8 +29,6 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 
 	const searchIndex = useRef(null)
 	const { availableValues } = state.context
-
-	const name = constraint.path.split('.').join(' > ')
 
 	useEffect(() => {
 		const buildIndex = async () => {
@@ -81,8 +81,8 @@ export const TemplateQuery = ({ classView, rootUrl, template }) => {
 	}
 
 	const [state] = useMachineBus(
-		templateQueryMachine.withContext({
-			...templateQueryMachine.context,
+		templateQueryMachine(`Template-${template.name} Query`).withContext({
+			...templateQueryMachine().context,
 			template: templateQuery,
 			isActiveQuery: false,
 		})

--- a/src/components/Templates/templateConstraintMachine.js
+++ b/src/components/Templates/templateConstraintMachine.js
@@ -35,78 +35,79 @@ const updateTemplateQuery = (ctx) => {
 	})
 }
 
-export const templateConstraintMachine = Machine(
-	{
-		id: 'Template constraint',
-		initial: 'loading',
-		context: {
-			rootUrl: '',
-			path: '',
-			op: '',
-			selectedValues: [],
-			availableValues: [],
-		},
-		states: {
-			loading: {
-				invoke: {
-					id: 'fetchTemplateConstraintValues',
-					src: 'fetchConstraintValues',
-					onDone: {
-						target: 'idle',
-						actions: 'setAvailableValues',
+export const templateConstraintMachine = (id = 'Template constraint widget') =>
+	Machine(
+		{
+			id,
+			initial: 'loading',
+			context: {
+				rootUrl: '',
+				path: '',
+				op: '',
+				selectedValues: [],
+				availableValues: [],
+			},
+			states: {
+				loading: {
+					invoke: {
+						id: 'fetchTemplateConstraintValues',
+						src: 'fetchConstraintValues',
+						onDone: {
+							target: 'idle',
+							actions: 'setAvailableValues',
+						},
+						onError: {
+							target: 'noValuesForConstraint',
+							actions: 'logErrorToConsole',
+						},
 					},
-					onError: {
-						target: 'noValuesForConstraint',
-						actions: 'logErrorToConsole',
+				},
+				noValuesForConstraint: {},
+				idle: {
+					on: {
+						[ADD_CONSTRAINT]: { target: 'updateTemplateQuery', actions: 'addConstraint' },
+						[REMOVE_CONSTRAINT]: { target: 'updateTemplateQuery', actions: 'removeConstraint' },
+					},
+				},
+				updateTemplateQuery: {
+					entry: 'updateTemplateQuery',
+					on: {
+						[TEMPLATE_CONSTRAINT_UPDATED]: { target: 'idle', cond: 'constraintUpdated' },
+					},
+				},
+				// delay the finished transition to avoid quick flashes of animations
+				pending: {
+					after: {
+						500: [{ target: 'idle', cond: 'hasValues' }, { target: 'noValuesForConstraint' }],
 					},
 				},
 			},
-			noValuesForConstraint: {},
-			idle: {
-				on: {
-					[ADD_CONSTRAINT]: { target: 'updateTemplateQuery', actions: 'addConstraint' },
-					[REMOVE_CONSTRAINT]: { target: 'updateTemplateQuery', actions: 'removeConstraint' },
+		},
+		{
+			actions: {
+				logErrorToConsole,
+				addConstraint,
+				removeConstraint,
+				setAvailableValues,
+				updateTemplateQuery,
+			},
+			guards: {
+				// @ts-ignore
+				constraintUpdated: (ctx, { path }) => {
+					return ctx.path === path
+				},
+				hasValues: (ctx) => {
+					return ctx.availableValues.length > 0
 				},
 			},
-			updateTemplateQuery: {
-				entry: 'updateTemplateQuery',
-				on: {
-					[TEMPLATE_CONSTRAINT_UPDATED]: { target: 'idle', cond: 'constraintUpdated' },
-				},
-			},
-			// delay the finished transition to avoid quick flashes of animations
-			pending: {
-				after: {
-					500: [{ target: 'idle', cond: 'hasValues' }, { target: 'noValuesForConstraint' }],
-				},
-			},
-		},
-	},
-	{
-		actions: {
-			logErrorToConsole,
-			addConstraint,
-			removeConstraint,
-			setAvailableValues,
-			updateTemplateQuery,
-		},
-		guards: {
-			// @ts-ignore
-			constraintUpdated: (ctx, { path }) => {
-				return ctx.path === path
-			},
-			hasValues: (ctx) => {
-				return ctx.availableValues.length > 0
-			},
-		},
-		services: {
-			fetchConstraintValues: async (ctx) => {
-				const values = await fetchPathValues({ rootUrl: ctx.rootUrl, path: ctx.path })
+			services: {
+				fetchConstraintValues: async (ctx) => {
+					const values = await fetchPathValues({ rootUrl: ctx.rootUrl, path: ctx.path })
 
-				return {
-					values,
-				}
+					return {
+						values,
+					}
+				},
 			},
-		},
-	}
-)
+		}
+	)

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -63,36 +63,37 @@ const templateHasQuery = (ctx, { path }) => {
 /**
  *
  */
-export const templateQueryMachine = Machine(
-	{
-		id: 'Template query machine',
-		initial: 'idle',
-		context: {
-			template: null,
-			isActiveQuery: false,
-			listNames: [],
-		},
-		states: {
-			idle: {
-				on: {
-					[ADD_TEMPLATE_CONSTRAINT]: { actions: 'setQueries', cond: 'templateHasQuery' },
-					[FETCH_UPDATED_SUMMARY]: { actions: 'setActiveQuery' },
-					[ADD_LIST_CONSTRAINT]: { actions: 'addListConstraint' },
-					[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
+export const templateQueryMachine = (id = 'Template Query') =>
+	Machine(
+		{
+			id,
+			initial: 'idle',
+			context: {
+				template: null,
+				isActiveQuery: false,
+				listNames: [],
+			},
+			states: {
+				idle: {
+					on: {
+						[ADD_TEMPLATE_CONSTRAINT]: { actions: 'setQueries', cond: 'templateHasQuery' },
+						[FETCH_UPDATED_SUMMARY]: { actions: 'setActiveQuery' },
+						[ADD_LIST_CONSTRAINT]: { actions: 'addListConstraint' },
+						[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
+					},
 				},
 			},
 		},
-	},
-	{
-		actions: {
-			setQueries,
-			setActiveQuery,
-			addListConstraint,
-			removeListConstraint,
-		},
-		guards: {
-			// @ts-ignore
-			templateHasQuery,
-		},
-	}
-)
+		{
+			actions: {
+				setQueries,
+				setActiveQuery,
+				addListConstraint,
+				removeListConstraint,
+			},
+			guards: {
+				// @ts-ignore
+				templateHasQuery,
+			},
+		}
+	)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,20 +4,7 @@ import {
 	SET_INITIAL_ORGANISMS,
 	TOGGLE_CATEGORY_VISIBILITY,
 } from 'src/eventConstants'
-import {
-	EventData,
-	EventObject,
-	Interpreter,
-	InterpreterOptions,
-	MachineConfig,
-	MachineOptions,
-	State,
-	StateConfig,
-	StateMachine,
-	StateNode,
-	StateSchema,
-	Typestate,
-} from 'xstate'
+import { EventObject, MachineConfig, StateMachine, StateNode, StateSchema, Typestate } from 'xstate'
 
 import {
 	ADD_CONSTRAINT,
@@ -155,39 +142,3 @@ export type QueryMachineConfig = MachineConfig<
 	QueryMachineSchema,
 	QueryMachineEvents
 >
-
-/**
- * Machine bus
- */
-interface UseMachineOptions<TContext, TEvent extends EventObject> {
-	/**
-	 * If provided, will be merged with machine's `context`.
-	 */
-	context?: Partial<TContext>
-	/**
-	 * If `true`, service will start immediately (before mount).
-	 */
-	immediate: boolean
-	/**
-	 * The state to rehydrate the machine to. The machine will
-	 * start at this state instead of its `initialState`.
-	 */
-	state?: StateConfig<TContext, TEvent>
-}
-
-export type UseMachineBus = <TContext, TEvent extends EventObject>(
-	machine: StateMachine<TContext, any, TEvent>,
-	options?: Partial<InterpreterOptions> &
-		Partial<UseMachineOptions<TContext, TEvent>> &
-		Partial<MachineOptions<TContext, TEvent>>
-) => [State<TContext, TEvent>, SendToBusWrapper, Interpreter<TContext, any, TEvent>]
-
-export type SendToBusWrapper = (
-	event: ConstraintEvents,
-	payload?: EventData | undefined
-) => State<
-	ConstraintMachineContext,
-	ConstraintEvents,
-	ConstraintMachineSchema,
-	ConstraintTypeState
-> | void

--- a/src/useMachineBus.js
+++ b/src/useMachineBus.js
@@ -1,5 +1,5 @@
-import { useMachine } from '@xstate/react'
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { interpret, State } from 'xstate'
 
 const enableMocks =
 	// istanbul ignore
@@ -15,8 +15,44 @@ export const TableServiceContext = createContext(null)
 
 const serviceStations = new Map()
 
-/** @type {import('./types').UseMachineBus} */
+const ReactEffectType = {
+	Effect: 1,
+	LayoutEffect: 2,
+}
+
+const partition = (items, predicate) => {
+	const [truthy, falsy] = [[], []]
+	for (const item of items) {
+		if (predicate(item)) {
+			truthy.push(item)
+		} else {
+			falsy.push(item)
+		}
+	}
+
+	return [truthy, falsy]
+}
+
+const executeEffect = (action, state) => {
+	const { exec } = action
+	const originalExec = exec(state.context, state._event.data, {
+		action,
+		state,
+		_event: state._event,
+	})
+
+	originalExec()
+}
+
+/**
+ * This is a slightly modified version of `xstate`s `useMachine` that allows components to
+ * reuse an already interpreted machine. It does so by caching the service in the service station bus.
+ *
+ * N.B: Since the machines are **never** stopped, components are responsible for stopping them if
+ * and where necessary
+ */
 export const useMachineBus = (machine, opts = {}) => {
+	// Allows mocking tests
 	const mockMachine = useContext(MockMachineContext)
 	let activeMachine = machine
 
@@ -27,36 +63,110 @@ export const useMachineBus = (machine, opts = {}) => {
 		}
 	}
 
-	const [machineState, , service] = useMachine(activeMachine, opts)
+	const {
+		context,
+		guards,
+		actions,
+		activities,
+		services,
+		delays,
+		state: rehydratedState,
+		...interpreterOptions
+	} = opts
 
-	/** @type {import('./types').SendToBusWrapper} */
-	const sendToBusWrapper = useMemo(() => {
-		return (event, payload) => {
-			const receiver = serviceStations.get(service.sessionId)
-
-			if (receiver) {
-				receiver.send(event, payload)
-			} else {
-				const e = new Error()
-				e.name = 'MessageBus'
-				e.message = 'Could not locate a service in the bus stations'
-				throw e
-			}
-		}
-	}, [service.sessionId])
-
-	const existing = serviceStations.get(service.sessionId)
-
-	if (!existing) {
-		serviceStations.set(service.sessionId, service)
+	const machineConfig = {
+		context,
+		guards,
+		actions,
+		activities,
+		services,
+		delays,
 	}
 
-	// Remove the service from the station when components unmount
-	service.onStop(() => {
-		serviceStations.delete(service.sessionId)
-	})
+	let service = serviceStations.get(activeMachine.id)
+	let serviceState = service?.state
 
-	return [machineState, sendToBusWrapper, service]
+	if (!service) {
+		const resolvedMachine = machine.withConfig(machineConfig, {
+			...activeMachine.context,
+			...context,
+		})
+
+		serviceState = rehydratedState ? State.create(rehydratedState) : resolvedMachine.initialState
+		service = interpret(resolvedMachine, { deferEvents: true, ...interpreterOptions })
+
+		serviceStations.set(activeMachine.id, service)
+	}
+
+	const [state, setState] = useState(serviceState)
+
+	const effectActionsRef = useRef([])
+	const layoutEffectActionsRef = useRef([])
+
+	useEffect(() => {
+		const handleStateChange = (currentState) => {
+			const initialStateChanged =
+				currentState.changed === undefined && Object.keys(currentState.children).length
+
+			if (currentState.changed || initialStateChanged) {
+				setState(currentState)
+			}
+
+			if (currentState.actions.length) {
+				const reactEffectActions = currentState.actions.filter((action) => {
+					return typeof action.exec === 'function' && '__effect' in action.exec
+				})
+
+				const [effectActions, layoutEffectActions] = partition(reactEffectActions, (action) => {
+					return action.exec.__effect === ReactEffectType.Effect
+				})
+
+				effectActionsRef.current.push(
+					...effectActions.map((effectAction) => [effectAction, currentState])
+				)
+
+				layoutEffectActionsRef.current.push(
+					...layoutEffectActions.map((layoutEffectAction) => [layoutEffectAction, currentState])
+				)
+			}
+		}
+
+		service
+			.onTransition(handleStateChange)
+			.start(rehydratedState ? State.create(rehydratedState) : undefined)
+
+		return () => service.off(handleStateChange)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
+
+	// Make sure actions and services are kept updated when they change.
+	// This mutation assignment is safe because the service instance is only used
+	// in one place -- this hook's caller.
+	useEffect(() => {
+		Object.assign(service.machine.options.actions, actions)
+	}, [actions, service.machine.options.actions])
+
+	useEffect(() => {
+		Object.assign(service.machine.options.services, services)
+	}, [service.machine.options.services, services])
+
+	useEffect(() => {
+		while (layoutEffectActionsRef.current.length) {
+			const [layoutEffectAction, effectState] = layoutEffectActionsRef.current.shift()
+
+			executeEffect(layoutEffectAction, effectState)
+		}
+	}, [state])
+
+	useEffect(() => {
+		while (effectActionsRef.current.length) {
+			const [effectAction, effectState] = effectActionsRef.current.shift()
+
+			executeEffect(effectAction, effectState)
+		}
+	}, [state])
+
+	return [state, service.send, service]
 }
 
 /**


### PR DESCRIPTION
`xstate` machines are stopped whenever the component mounts if we use
its `useMachineBus` method. This is not ideal, because it means that
the components have to refetch their values on every fresh mount. Taking
into account that some mines may have large latency, we need to keep the
api calls running in the background. The idiomatic way to prevent this,
would be to create services and pass that to the child components.

The issue with that is that we have nested components with child nested
components, that each make their own specific calls. Spawning new actors
using `xstate` would lead to hard to track down state bugs.

Therefore this PR provides a modified version of `useMachine` that
does not stop the running services. Instead, it will reuse one with a
similar machine id. This allows components to finish their api calls in
the background should a user click out of a popup panel.

Closes: #112 