### PR TITLE
Allow the user to set and save an api token for each mine

### DIFF
--- a/src/blueprintIcons.js
+++ b/src/blueprintIcons.js
@@ -4,7 +4,7 @@ exports.usedIcons = [
 	IconNames.DISABLE,
 	IconNames.PLAY,
 	IconNames.TICK_CIRCLE,
-	IconNames.UNLOCK,
+	IconNames.KEY,
 	IconNames.LOCK,
 	IconNames.CARET_DOWN,
 	IconNames.CARET_RIGHT,

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -1,28 +1,32 @@
-import { Button, Colors, Icon } from '@blueprintjs/core'
+import { Button, Colors, Icon, InputGroup, Popover } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
-import React, { useState } from 'react'
-import { CHANGE_MINE } from 'src/eventConstants'
+import React, { useEffect, useState } from 'react'
+import { CHANGE_MINE, SET_API_TOKEN } from 'src/eventConstants'
 import { useServiceContext } from 'src/useMachineBus'
 
 import { NumberedSelectMenuItems } from '../Shared/Selects'
 
-const AuthenticatedIcon = (isAuthenticated) => (
-	<Icon
-		icon={isAuthenticated ? IconNames.UNLOCK : IconNames.LOCK}
-		color={isAuthenticated ? Colors.GREEN5 : Colors.RED3}
-	/>
-)
-
 export const MineSelector = () => {
-	const [isAuthenticated, setAuthentication] = useState(false)
 	const [state, send] = useServiceContext('appManager')
+	const [showPopup, setShowPopup] = useState(false)
 
 	const { selectedMine, intermines } = state.context
+	const [apiToken, setApiToken] = useState(selectedMine.apiToken)
+	const [currentMine, setCurrentMine] = useState(selectedMine.rootUrl)
+
+	useEffect(() => {
+		if (currentMine !== selectedMine.rootUrl) {
+			setCurrentMine(selectedMine.rootUrl)
+			setApiToken(selectedMine.apiToken)
+		}
+	}, [currentMine, selectedMine.rootUrl, selectedMine.apiToken])
 
 	const handleMineChange = ({ name }) => {
 		send({ type: CHANGE_MINE, newMine: name })
 	}
+
+	const isAuthenticated = selectedMine.apiToken.length > 0
 
 	return (
 		<>
@@ -72,14 +76,35 @@ export const MineSelector = () => {
 						marginBottom: 0,
 					}}
 				>
-					Api
+					Key
 				</span>
-				<Button
-					aria-label="api-status"
-					small={true}
-					icon={AuthenticatedIcon(isAuthenticated)}
-					onClick={() => setAuthentication(!isAuthenticated)}
-				/>
+				<Popover
+					onClose={() => send({ type: SET_API_TOKEN, apiToken })}
+					isOpen={showPopup}
+					onInteraction={(nextState) => setShowPopup(nextState)}
+				>
+					<Button
+						aria-label="api-status"
+						small={true}
+						icon={
+							<Icon icon={IconNames.KEY} color={isAuthenticated ? Colors.GREEN5 : Colors.RED3} />
+						}
+					/>
+					<InputGroup
+						large={true}
+						leftIcon="key"
+						onChange={(e) => setApiToken(e.target.value)}
+						placeholder="Enter your api key"
+						value={apiToken}
+						onKeyDown={(e) => {
+							const code = e.keyCode ? e.keyCode : e.which
+							// enter key
+							if (code === 13) {
+								setShowPopup(false)
+							}
+						}}
+					/>
+				</Popover>
 			</div>
 		</>
 	)

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -45,6 +45,7 @@ export const TOGGLE_CATEGORY_VISIBILITY = 'appManager/category/visibility'
 export const TOGGLE_VIEW_IS_LOADING = 'appManager/view/isLoading'
 export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
+export const SET_API_TOKEN = 'appManager/api/token'
 
 /**
  * Table


### PR DESCRIPTION
The user can now enter an api key for each mine. The keys are saved in
localStorage and are retrieved when the mine is first loaded, or when
it changes.

Closes: #116 