### PR TITLE
Select an item when the user clicks on enter

### DIFF
--- a/src/components/Widgets/SuggestWidget.jsx
+++ b/src/components/Widgets/SuggestWidget.jsx
@@ -164,6 +164,7 @@ export const SuggestWidget = ({
 					className={isLoading ? Classes.SKELETON : ''}
 					resetOnSelect={true}
 					itemListRenderer={renderMenu(handleItemSelect)}
+					onItemSelect={({ item }) => handleItemSelect({ name: item })}
 					itemListPredicate={filterQuery}
 					popoverProps={{ captureDismiss: true }}
 				/>


### PR DESCRIPTION
This fixes a regression where I removed `onItemSelect` and the items
were not being added to the selections with the enter key.

Closes: #120 