### PR TITLE
Remove selected items from input widgets

### DIFF
--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -130,13 +130,14 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 	const constraintCount = state.context.selectedValues.length
 	const searchIndex = useRef(null)
 	const { availableValues } = state.context
+	const docField = 'item'
 
 	useEffect(() => {
 		const buildIndex = async () => {
 			if (type === 'select' && searchIndex.current === null && availableValues.length > 0) {
 				searchIndex.current = await buildSearchIndex({
+					docField,
 					docId: 'item',
-					docField: 'item',
 					values: availableValues,
 				})
 			}
@@ -197,6 +198,7 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 							nonIdealDescription="If you feel this is a mistake, try refreshing the browser. If that doesn't work, let us know"
 							// @ts-ignore
 							searchIndex={searchIndex}
+							docField={docField}
 						/>
 					</ConstraintCard>
 				</div>

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -29,13 +29,14 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 
 	const searchIndex = useRef(null)
 	const { availableValues } = state.context
+	const docField = 'item'
 
 	useEffect(() => {
 		const buildIndex = async () => {
 			if (searchIndex.current === null && availableValues.length > 0) {
 				searchIndex.current = await buildSearchIndex({
+					docField,
 					docId: 'item',
-					docField: 'item',
 					values: availableValues,
 				})
 			}
@@ -56,6 +57,7 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 					nonIdealDescription="If you feel this is a mistake, try refreshing the browser. If that doesn't work, let us know"
 					// @ts-ignore
 					searchIndex={searchIndex}
+					docField={docField}
 				/>
 			</div>
 		</ConstraintServiceContext.Provider>

--- a/src/components/Widgets/SuggestWidget.jsx
+++ b/src/components/Widgets/SuggestWidget.jsx
@@ -101,6 +101,7 @@ export const SuggestWidget = ({
 	nonIdealDescription = undefined,
 	label = '',
 	searchIndex,
+	docField = '',
 }) => {
 	const [uniqueId] = useState(() => `selectPopup-${generateId()}`)
 	const [state, send] = useServiceContext('constraints')
@@ -116,11 +117,27 @@ export const SuggestWidget = ({
 	const renderInputValue = () => ''
 	const filterQuery = (query, items) => {
 		if (query === '' || searchIndex.current === null) {
-			return items.filter((i) => !selectedValues.includes(i.name))
+			return items.filter((i) => !selectedValues.includes(i.item))
 		}
 
+		const negateSelected = selectedValues.map((val) => ({
+			field: docField,
+			query: val,
+			bool: 'not',
+		}))
+
 		// flexSearch's default result limit is set 1000, so we set it to the length of all items
-		const results = searchIndex.current.search(query, availableValues.length)
+		const results = searchIndex.current.search(
+			[
+				{
+					field: docField,
+					query,
+					bool: 'and',
+				},
+				...negateSelected,
+			],
+			availableValues.length
+		)
 
 		return results
 	}


### PR DESCRIPTION
The selected items were showing up for filterable input widgets. This
led to the possibility of adding duplicates. This commit filters empty
queries to remove the selected values, and performs negated searches for
queries that have text input.

Closes: #122 