### PR TITLE
Show the status of whether lists are applied

### DIFF
--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -7,6 +7,7 @@ import { ADD_LIST_CONSTRAINT, ADD_LIST_TAG } from 'src/eventConstants'
 import { sendToBus } from 'src/useMachineBus'
 import { pluralizeFilteredCount } from 'src/utils'
 
+import { ConstraintSetTag } from '../Shared/ConstraintSetTag'
 import { InfoIconPopover } from '../Shared/InfoIconPopover'
 
 export const ListMenuItems = (item, props) => {
@@ -93,7 +94,7 @@ export const ListSelector = ({ listsForCurrentClass }) => {
 	}
 
 	return (
-		<div css={{ display: 'flex', marginLeft: 40, marginRight: 20 }}>
+		<div css={{ display: 'flex', alignItems: 'center', marginLeft: 40, marginRight: 20 }}>
 			<span
 				// @ts-ignore
 				css={{
@@ -124,6 +125,9 @@ export const ListSelector = ({ listsForCurrentClass }) => {
 					rightIcon={IconNames.CARET_DOWN}
 				/>
 			</Select>
+			<div css={{ marginLeft: 10 }}>
+				<ConstraintSetTag constraintApplied={selectedValues.length > 0} text="List Set" />
+			</div>
 		</div>
 	)
 }

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Icon, Tag } from '@blueprintjs/core'
+import { Button, ButtonGroup, Icon } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
@@ -7,6 +7,7 @@ import { buildSearchIndex } from 'src/buildSearchIndex'
 import { APPLY_DATA_BROWSER_CONSTRAINT, RESET_LOCAL_CONSTRAINT } from 'src/eventConstants'
 import { ConstraintServiceContext, useMachineBus, useServiceContext } from 'src/useMachineBus'
 
+import { ConstraintSetTag } from '../Shared/ConstraintSetTag'
 import { PopupCard } from '../Shared/PopupCard'
 import { CheckboxWidget } from '../Widgets/CheckboxWidget'
 import { SuggestWidget } from '../Widgets/SuggestWidget'
@@ -23,31 +24,10 @@ const ConstraintCard = ({ children }) => {
 	const enableAdd = state.matches('constraintsUpdated')
 	const constraintApplied = !disableAllButtons && !enableAdd
 
-	const borderColor = constraintApplied ? 'var(--blue4)' : 'var(--grey4)'
-	const iconColor = constraintApplied ? 'var(--green5)' : 'var(--grey4)'
-	const textColor = constraintApplied ? 'var(--blue9)' : 'var(--grey4)'
-
 	return (
 		<>
 			<div css={{ display: 'flex', justifyContent: 'center', marginBottom: 16 }}>
-				<Tag
-					css={{
-						backgroundColor: 'unset',
-						border: `1px solid ${borderColor}`,
-						color: iconColor,
-					}}
-					// @ts-ignore
-					intent="" // HACK - decreases blueprintjs css specificity
-					icon={constraintApplied ? IconNames.TICK_CIRCLE : IconNames.DISABLE}
-					minimal={true}
-				>
-					<span
-						// @ts-ignore
-						css={{ color: textColor, fontWeight: 'var(--fw-medium)' }}
-					>
-						Constraint Set
-					</span>
-				</Tag>
+				<ConstraintSetTag constraintApplied={constraintApplied} text="Constraint Set" />
 			</div>
 			{children}
 			<ButtonGroup fill={true} css={{ marginTop: 48 }}>

--- a/src/components/Shared/ConstraintSetTag.jsx
+++ b/src/components/Shared/ConstraintSetTag.jsx
@@ -1,0 +1,30 @@
+import { Tag } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+import React from 'react'
+
+export const ConstraintSetTag = ({ constraintApplied, text }) => {
+	const borderColor = constraintApplied ? 'var(--blue4)' : 'var(--grey4)'
+	const iconColor = constraintApplied ? 'var(--green5)' : 'var(--grey4)'
+	const textColor = constraintApplied ? 'var(--blue9)' : 'var(--grey4)'
+
+	return (
+		<Tag
+			css={{
+				backgroundColor: 'unset',
+				border: `1px solid ${borderColor}`,
+				color: iconColor,
+			}}
+			// @ts-ignore
+			intent="" // HACK - decreases blueprintjs css specificity
+			icon={constraintApplied ? IconNames.TICK_CIRCLE : IconNames.DISABLE}
+			minimal={true}
+		>
+			<span
+				// @ts-ignore
+				css={{ color: textColor, fontWeight: 'var(--fw-medium)' }}
+			>
+				{text}
+			</span>
+		</Tag>
+	)
+}


### PR DESCRIPTION
At the moment the status of applying lists was only shown in both the
overview constraint `view all` popup, and the templates constraint `list`
section. This PR displays a tag next to the lists dropdown so that
the user doesn't have to open either of those to know if lists are applied.

Closes: #124 