### PR TITLE
Save serialized search indexes in local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"flexsearch": "^0.6.32",
 		"imjs": "^4.0.0",
 		"immer": "^7.0.5",
+		"localforage": "^1.8.1",
 		"nanoid": "^3.1.10",
 		"nanoid-dictionary": "^3.0.0",
 		"react": "^16.13.1",

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -73,6 +73,7 @@ export const App = () => {
 					classView={classView}
 					rootUrl={rootUrl}
 					showAll={categories[showAllLabel]?.isVisible ?? true}
+					mineName={selectedMine.name}
 				/>
 				<section
 					id="data-viz"

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -120,6 +120,7 @@ const TemplatesList = ({
 	classView,
 	rootUrl,
 	listNames,
+	mineName,
 }) => {
 	return (
 		<div>
@@ -138,7 +139,12 @@ const TemplatesList = ({
 				{!isLoading &&
 					queries.map((template) => (
 						<li key={template.name} css={{ margin: '0.875em 0' }}>
-							<TemplateQuery classView={classView} rootUrl={rootUrl} template={template} />
+							<TemplateQuery
+								classView={classView}
+								rootUrl={rootUrl}
+								template={template}
+								mineName={mineName}
+							/>
 						</li>
 					))}
 			</ul>
@@ -146,7 +152,7 @@ const TemplatesList = ({
 	)
 }
 
-const OverviewConstraintList = ({ queries, isLoading }) => {
+const OverviewConstraintList = ({ queries, isLoading, mineName }) => {
 	if (isLoading) {
 		return null
 	}
@@ -164,6 +170,7 @@ const OverviewConstraintList = ({ queries, isLoading }) => {
 					<OverviewConstraint
 						constraintConfig={config}
 						color={DATA_VIZ_COLORS[idx % DATA_VIZ_COLORS.length]}
+						mineName={mineName}
 					/>
 				</li>
 			))}
@@ -181,6 +188,7 @@ export const ConstraintSection = ({
 	classView,
 	rootUrl,
 	showAll,
+	mineName,
 }) => {
 	const [state] = useMachineBus(constraintSectionMachine)
 
@@ -219,11 +227,12 @@ export const ConstraintSection = ({
 					classView={classView}
 					rootUrl={rootUrl}
 					listNames={listNames}
+					mineName={mineName}
 				/>
 			) : (
 				<>
 					<QueryController />
-					<OverviewConstraintList queries={queries} isLoading={isLoading} />
+					<OverviewConstraintList queries={queries} isLoading={isLoading} mineName={mineName} />
 				</>
 			)}
 		</section>

--- a/src/components/Navigation/ClassSelector.jsx
+++ b/src/components/Navigation/ClassSelector.jsx
@@ -21,7 +21,7 @@ const renderMenu = ({ filteredItems, itemsParentRef, query, renderItem }) => {
 	)
 }
 
-export const ClassSelector = ({ handleClassSelect, modelClasses, classView }) => {
+export const ClassSelector = ({ handleClassSelect, modelClasses, classView, mineName }) => {
 	const classSearchIndex = useRef(null)
 
 	const classDisplayName =
@@ -34,12 +34,13 @@ export const ClassSelector = ({ handleClassSelect, modelClasses, classView }) =>
 					docId: 'name',
 					docField: 'displayName',
 					values: modelClasses,
+					cacheKey: `${mineName}-classSelector`,
 				})
 			}
 		}
 
 		indexClasses()
-	}, [modelClasses])
+	}, [modelClasses, mineName])
 
 	const filterQuery = (query, items) => {
 		if (query === '' || !classSearchIndex?.current) {

--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -42,7 +42,7 @@ const renderMenu = ({ filteredItems, itemsParentRef, query, renderItem }) => {
 	)
 }
 
-export const ListSelector = ({ listsForCurrentClass }) => {
+export const ListSelector = ({ listsForCurrentClass, mineName }) => {
 	const listSearchIndex = useRef(null)
 	const [selectedValues, setSelectedValues] = useState([])
 
@@ -53,12 +53,13 @@ export const ListSelector = ({ listsForCurrentClass }) => {
 					docId: 'listName',
 					docField: 'displayName',
 					values: listsForCurrentClass,
+					cacheKey: `${mineName}-listSelector`,
 				})
 			}
 		}
 
 		indexClasses()
-	}, [listsForCurrentClass])
+	}, [listsForCurrentClass, mineName])
 
 	const filterQuery = (query, items) => {
 		if (query === '' || !listSearchIndex?.current) {

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -12,7 +12,7 @@ import { MineSelector } from './MineSelector'
  */
 export const NavigationBar = () => {
 	const [state, send] = useServiceContext('appManager')
-	const { classView, modelClasses, listsForCurrentClass } = state.context
+	const { classView, modelClasses, listsForCurrentClass, selectedMine } = state.context
 
 	const handleClassSelect = ({ name }) => {
 		send({ type: CHANGE_CLASS, newClass: name })
@@ -26,8 +26,9 @@ export const NavigationBar = () => {
 					handleClassSelect={handleClassSelect}
 					modelClasses={modelClasses}
 					classView={classView}
+					mineName={selectedMine.name}
 				/>
-				<ListSelector listsForCurrentClass={listsForCurrentClass} />
+				<ListSelector listsForCurrentClass={listsForCurrentClass} mineName={selectedMine.name} />
 			</Navbar.Group>
 		</Navbar>
 	)

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -94,7 +94,7 @@ const S_ConstraintIcon = styled.div`
 	justify-content: center;
 `
 
-export const OverviewConstraint = ({ constraintConfig, color }) => {
+export const OverviewConstraint = ({ constraintConfig, color, mineName }) => {
 	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
 	const [state, send] = useMachineBus(
@@ -119,12 +119,13 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 					docField,
 					docId: 'item',
 					values: availableValues,
+					cacheKey: `${mineName}-overview-${path}-values`,
 				})
 			}
 		}
 
 		buildIndex()
-	}, [availableValues, type])
+	}, [availableValues, mineName, path, type])
 
 	let ConstraintWidget
 

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -14,7 +14,7 @@ import { SuggestWidget } from '../Widgets/SuggestWidget'
 import { templateConstraintMachine } from './templateConstraintMachine'
 import { templateQueryMachine } from './templateQueryMachine'
 
-const ConstraintWidget = ({ constraint, rootUrl }) => {
+const ConstraintWidget = ({ constraint, rootUrl, mineName }) => {
 	const name = constraint.path.split('.').join(' > ')
 
 	const [state, send] = useMachineBus(
@@ -29,21 +29,22 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 
 	const searchIndex = useRef(null)
 	const { availableValues } = state.context
-	const docField = 'item'
+	const docField = 'value'
 
 	useEffect(() => {
 		const buildIndex = async () => {
 			if (searchIndex.current === null && availableValues.length > 0) {
 				searchIndex.current = await buildSearchIndex({
 					docField,
-					docId: 'item',
+					docId: 'value',
 					values: availableValues,
+					cacheKey: `${mineName}-template-${constraint.path}-values`,
 				})
 			}
 		}
 
 		buildIndex()
-	}, [availableValues])
+	}, [availableValues, constraint.path, mineName])
 
 	const Widget =
 		availableValues.length <= 10 && constraint.op === 'ONE OF' ? CheckboxWidget : SuggestWidget
@@ -64,7 +65,7 @@ const ConstraintWidget = ({ constraint, rootUrl }) => {
 	)
 }
 
-export const TemplateQuery = ({ classView, rootUrl, template }) => {
+export const TemplateQuery = ({ classView, rootUrl, template, mineName }) => {
 	// We don't provide default values for the templates
 	const withNoDefaults = [...template.where].map((con) => {
 		if ('value' in con) {
@@ -130,7 +131,7 @@ export const TemplateQuery = ({ classView, rootUrl, template }) => {
 			{editableConstraints.map((con, idx) => {
 				return (
 					<div key={con.path}>
-						<ConstraintWidget constraint={con} rootUrl={rootUrl} />
+						<ConstraintWidget constraint={con} rootUrl={rootUrl} mineName={mineName} />
 						{showDivider(idx) && <Divider />}
 					</div>
 				)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12597,6 +12597,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: e86d4d20e2da86f9a4629d9aee9d56dfae7d3a7ace7f569b0538f2ec2570d86b3cbdc52c546d23be2cfd28306670f44676fc833cd96d9506659b8c5ab8202ca4
+  languageName: node
+  linkType: hard
+
 "immer@npm:1.10.0":
   version: 1.10.0
   resolution: "immer@npm:1.10.0"
@@ -12863,6 +12870,7 @@ fsevents@^1.2.7:
     immer: ^7.0.5
     jest-axe: ^3.4.0
     lint-staged: ">=10"
+    localforage: ^1.8.1
     nanoid: ^3.1.10
     nanoid-dictionary: ^3.0.0
     node-sass: ^4.14.1
@@ -14801,6 +14809,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lie@npm:3.1.1":
+  version: 3.1.1
+  resolution: "lie@npm:3.1.1"
+  dependencies:
+    immediate: ~3.0.5
+  checksum: 33a07ffeb7eb5aaec59a5f7a72ba7e6a2ce9d011bd7894f36ed11e2da43f076467019e5f9826c5864500c6a792450aa54b263f31cef0a1774553851dce8a501c
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.1.6
   resolution: "lines-and-columns@npm:1.1.6"
@@ -14935,6 +14952,15 @@ fsevents@^1.2.7:
     emojis-list: ^3.0.0
     json5: ^1.0.1
   checksum: 9fd690e57ad78d32ff2942383b4a7a175eba575280ba5aca3b4d03183fec34aa0db314f49bd3301adf7e60b02471644161bf53149e8f2d18fd6a52627e95a927
+  languageName: node
+  linkType: hard
+
+"localforage@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "localforage@npm:1.8.1"
+  dependencies:
+    lie: 3.1.1
+  checksum: 7530b213d2b4c3e40455bc2b69f241f9e8cd7b643e9fc4c67eb522f3a29f44306fc800a30a5513c0444788606e3c72404d9fe68b0cf20e7bf405efad2de449b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The indexes for filterable input widgets is expensive to build, and were
being rebuilt every time the components rendered. This commit save the
index to local storage so that they can be indexed just once.

N.B: This PR does not address setting an expiry date to this cache.
Further discussion needs to happen to decide on the best approach for that
moving forward.

Closes: #126 