### PR TITLE
Fix: noticeable lag when switching between overview and template views

### DIFF
--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -54,7 +54,7 @@ const colorizeBars = (data, isLoading) =>
 		/>
 	))
 
-export const BarChart = () => {
+export const BarChart = React.memo(function BarChart() {
 	const isFirstRender = useFirstMountState()
 	const [state] = useMachineBus(BarChartMachine)
 
@@ -153,4 +153,4 @@ export const BarChart = () => {
 			)}
 		</>
 	)
-}
+})

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -60,7 +60,7 @@ const renderLoadingLabel = (props) => {
 	)
 }
 
-export const PieChart = () => {
+export const PieChart = React.memo(function PieChart() {
 	const isFirstRender = useFirstMountState()
 	const [state] = useMachineBus(PieChartMachine)
 	const { allClassOrganisms, classView } = state.context
@@ -140,4 +140,4 @@ export const PieChart = () => {
 			{isLoading && <ProgressBar css={{ margin: '20px auto', width: '50%' }} intent="primary" />}
 		</>
 	)
-}
+})

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -217,7 +217,7 @@ const Cell = ({ cell, mineUrl, isLoading }) => {
 /**
  *
  */
-export const Table = () => {
+export const Table = React.memo(function Table() {
 	const isFirstRender = useFirstMountState()
 	const [state, send] = useMachineBus(TableChartMachine)
 
@@ -289,4 +289,4 @@ export const Table = () => {
 			</HTMLTable>
 		</TableServiceContext.Provider>
 	)
-}
+})


### PR DESCRIPTION
The lag occurred because the PieChart, BarChart, and Table components
would re-render since the parent component re-rendered. This PR
memoizes those components so that they only render when their own internal
state changes.

Closes: #128

Squashed commits:
* Memoize PieChart component
* Memoize BarChart component
* Memoize Table component