### PR TITLE
Fix: lists are not correctly formatted when being applied to queries

### DIFF
--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -1,7 +1,7 @@
-import { Button, Classes, Collapse, Divider, Tab, Tabs, Tag, Text } from '@blueprintjs/core'
+import { Button, Classes, Collapse, Divider, Tab, Tabs, Tag } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React, { useState } from 'react'
-import { CHANGE_CONSTRAINT_VIEW, REMOVE_LIST_CONSTRAINT, REMOVE_LIST_TAG } from 'src/eventConstants'
+import { CHANGE_CONSTRAINT_VIEW } from 'src/eventConstants'
 import { sendToBus, useMachineBus } from 'src/useMachineBus'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
@@ -64,52 +64,6 @@ const ShowCategories = ({
 	)
 }
 
-const ShowLists = ({ listNames }) => {
-	const [showLists, setShowLists] = useState(false)
-
-	const selectedLists = listNames.map((listName) => {
-		return (
-			<Tag
-				key={listName}
-				intent="primary"
-				interactive={true}
-				onRemove={() => {
-					// @ts-ignore
-					sendToBus({ type: REMOVE_LIST_CONSTRAINT, listName })
-					// @ts-ignore
-					sendToBus({ type: REMOVE_LIST_TAG, listName })
-				}}
-				css={{ margin: 4 }}
-			>
-				{listName}
-			</Tag>
-		)
-	})
-
-	return (
-		<>
-			<Button
-				icon={showLists ? IconNames.CARET_DOWN : IconNames.CARET_RIGHT}
-				fill={true}
-				alignText="left"
-				text="List Filters"
-				minimal={true}
-				large={true}
-				onClick={() => setShowLists(!showLists)}
-			/>
-			<Collapse isOpen={showLists} css={{ marginTop: 0 }}>
-				<div css={{ backgroundColor: 'var(--blue0)', padding: 10 }}>
-					{listNames.length > 0 ? (
-						selectedLists
-					) : (
-						<Text css={{ marginLeft: 20 }}>No Lists Selected</Text>
-					)}
-				</div>
-			</Collapse>
-		</>
-	)
-}
-
 const TemplatesList = ({
 	isLoading,
 	queries,
@@ -124,8 +78,6 @@ const TemplatesList = ({
 }) => {
 	return (
 		<div>
-			<Divider css={{ margin: 0 }} />
-			<ShowLists listNames={listNames} />
 			<Divider css={{ margin: 0 }} />
 			<ShowCategories
 				handleCategoryToggle={handleCategoryToggle}

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -2,11 +2,7 @@ import { Button, Divider, H4, H5, NonIdealState } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import PropTypes from 'prop-types'
 import React from 'react'
-import {
-	DELETE_QUERY_CONSTRAINT,
-	FETCH_UPDATED_SUMMARY,
-	REMOVE_LIST_CONSTRAINT,
-} from 'src/eventConstants'
+import { DELETE_QUERY_CONSTRAINT, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
 import { QueryServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
 
 import { CODES } from '../common'
@@ -78,33 +74,6 @@ CurrentConstraints.defaultProps = {
 	currentConstraints: [],
 }
 
-const ListContraintValues = ({ values, handleDeleteListConstraint }) => {
-	return (
-		<ul css={{ padding: '0 16px', listStyle: 'none' }}>
-			{values.map((value) => {
-				return (
-					<li key={value} css={{ padding: '6px 0' }}>
-						<div css={{ display: 'flex' }}>
-							<Button
-								intent="danger"
-								icon={IconNames.REMOVE}
-								small={true}
-								minimal={true}
-								onClick={() => handleDeleteListConstraint(value)}
-								aria-label={`delete ${value} from the list constraint`}
-								css={{ marginRight: 4 }}
-							/>
-							<span css={{ fontSize: 'var(--fs-desktopM1)', display: 'inline-block' }}>
-								{value}
-							</span>
-						</div>
-					</li>
-				)
-			})}
-		</ul>
-	)
-}
-
 export const QueryController = () => {
 	const [state, send] = useMachineBus(queryControllerMachine)
 
@@ -121,7 +90,10 @@ export const QueryController = () => {
 	const runQuery = () => {
 		let constraintLogic = ''
 
-		const codedConstraints = currentConstraints.map((con, idx) => {
+		const constraints =
+			listConstraint.value.length > 0 ? [...currentConstraints, listConstraint] : currentConstraints
+
+		const codedConstraints = constraints.map((con, idx) => {
 			const code = CODES[idx]
 			constraintLogic = constraintLogic === '' ? `(${code})` : `${constraintLogic} AND (${code})`
 
@@ -145,17 +117,12 @@ export const QueryController = () => {
 		send({ type: DELETE_QUERY_CONSTRAINT, path })
 	}
 
-	const handleDeleteListConstraint = (listName) => {
-		// @ts-ignore
-		sendToBus({ type: REMOVE_LIST_CONSTRAINT, listName })
-	}
-
-	const constraintCount = currentConstraints.length + listConstraint.values.length
-
 	return (
 		<div css={{ paddingTop: 10, margin: '0 20px' }}>
 			<H5>
-				<span css={{ color, display: 'inline-block', marginRight: 4 }}>{`${constraintCount}`}</span>
+				<span
+					css={{ color, display: 'inline-block', marginRight: 4 }}
+				>{`${currentConstraints.length}`}</span>
 				<span css={{ color: 'var(--blue9)' }}>Constraints applied</span>
 			</H5>
 			<PopupCard>
@@ -165,12 +132,6 @@ export const QueryController = () => {
 					<CurrentConstraints
 						constraints={currentConstraints}
 						handleDeleteConstraint={handleDeleteConstraint}
-					/>
-					<Divider css={{ width: '75%', marginBottom: 16 }} />
-					<H4>Lists</H4>
-					<ListContraintValues
-						values={listConstraint.values}
-						handleDeleteListConstraint={handleDeleteListConstraint}
 					/>
 					<Divider css={{ width: '75%', marginBottom: 16 }} />
 					<H4>History</H4>

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -68,18 +68,18 @@ const addListConstraint = assign({
 		return {
 			...ctx.listConstraint,
 			path: ctx.classView,
-			values: [...ctx.listConstraint.values, listName],
+			value: [listName],
 		}
 	},
 })
 
 const removeListConstraint = assign({
 	// @ts-ignore
-	listConstraint: (ctx, { listName }) => {
+	listConstraint: (ctx) => {
 		return {
 			...ctx.listConstraint,
 			path: ctx.classView,
-			values: ctx.listConstraint.values.filter((list) => list !== listName),
+			value: [],
 		}
 	},
 })
@@ -93,9 +93,7 @@ export const queryControllerMachine = Machine(
 		initial: 'idle',
 		context: {
 			currentConstraints: [],
-			listConstraint: {
-				...listConstraintQuery,
-			},
+			listConstraint: listConstraintQuery,
 			classView: '',
 			selectedPaths: [],
 			rootUrl: '',
@@ -165,7 +163,7 @@ export const queryControllerMachine = Machine(
 			isLastConstraint: (context, _, { cond }) => {
 				const maxConstraints =
 					// @ts-ignore
-					context.listConstraint.values.length === 0 ? cond.maxConstraints : cond.maxConstraints - 1 // subtract the list constraint
+					context.listConstraint.value.length === 0 ? cond.maxConstraints : cond.maxConstraints - 1 // subtract the list constraint
 
 				return context.currentConstraints.length + 1 === maxConstraints
 			},

--- a/src/components/Shared/ConstraintSetTag.jsx
+++ b/src/components/Shared/ConstraintSetTag.jsx
@@ -1,8 +1,8 @@
-import { Tag } from '@blueprintjs/core'
+import { Tag, Text } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
 
-export const ConstraintSetTag = ({ constraintApplied, text }) => {
+export const ConstraintSetTag = ({ constraintApplied, text, ellipsize = false }) => {
 	const borderColor = constraintApplied ? 'var(--blue4)' : 'var(--grey4)'
 	const iconColor = constraintApplied ? 'var(--green5)' : 'var(--grey4)'
 	const textColor = constraintApplied ? 'var(--blue9)' : 'var(--grey4)'
@@ -13,18 +13,21 @@ export const ConstraintSetTag = ({ constraintApplied, text }) => {
 				backgroundColor: 'unset',
 				border: `1px solid ${borderColor}`,
 				color: iconColor,
+				maxWidth: 120,
 			}}
 			// @ts-ignore
 			intent="" // HACK - decreases blueprintjs css specificity
 			icon={constraintApplied ? IconNames.TICK_CIRCLE : IconNames.DISABLE}
 			minimal={true}
 		>
-			<span
+			<Text
 				// @ts-ignore
 				css={{ color: textColor, fontWeight: 'var(--fw-medium)' }}
+				ellipsize={ellipsize}
+				tagName="span"
 			>
 				{text}
-			</span>
+			</Text>
 		</Tag>
 	)
 }

--- a/src/components/Shared/InfoIconPopover.jsx
+++ b/src/components/Shared/InfoIconPopover.jsx
@@ -2,20 +2,24 @@ import { H4, Icon, Popover, PopoverInteractionKind, Text } from '@blueprintjs/co
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
 
-export const InfoIconPopover = ({ description, position = 'auto', title }) => (
-	<Popover
-		interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
-		boundary="viewport"
-		css={{ marginRight: 20, marginLeft: 5 }}
-		usePortal={true}
-		lazy={true}
-		// @ts-ignore
-		position={position}
-	>
-		<Icon icon={IconNames.INFO_SIGN} color="var(--grey4)" iconSize={20} />
-		<div css={{ maxWidth: 500, padding: 20 }}>
-			{title && <H4>{title}</H4>}
-			<Text>{description ? description : 'No Description Provided'}</Text>
-		</div>
-	</Popover>
-)
+export const InfoIconPopover = ({ description, position = 'auto', title, intent = undefined }) => {
+	const colorProp = intent ? { intent } : { color: 'var(--grey4)' }
+
+	return (
+		<Popover
+			interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+			boundary="viewport"
+			css={{ marginRight: 20, marginLeft: 5 }}
+			usePortal={true}
+			lazy={true}
+			// @ts-ignore
+			position={position}
+		>
+			<Icon icon={IconNames.INFO_SIGN} iconSize={20} {...colorProp} />
+			<div css={{ maxWidth: 500, padding: 20 }}>
+				{title && <H4>{title}</H4>}
+				<Text>{description ? description : 'No Description Provided'}</Text>
+			</div>
+		</Popover>
+	)
+}

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -5,7 +5,7 @@ import { buildSearchIndex } from 'src/buildSearchIndex'
 import { FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
 import { ConstraintServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
 
-import { CODES, listConstraintQuery } from '../common'
+import { CODES } from '../common'
 import { RunQueryButton } from '../Shared/Buttons'
 import { InfoIconPopover } from '../Shared/InfoIconPopover'
 import { PopupCard } from '../Shared/PopupCard'
@@ -91,24 +91,27 @@ export const TemplateQuery = ({ classView, rootUrl, template, mineName }) => {
 		})
 	)
 
-	const { isActiveQuery, listNames, template: updatedTemplate } = state.context
+	const { isActiveQuery, listConstraint, template: updatedTemplate } = state.context
 
 	const showDivider = (idx) =>
 		editableConstraints.length > 1 && idx < editableConstraints.length - 1
 
-	const nextCode = CODES[updatedTemplate.where.length]
 	const query = {
 		...updatedTemplate,
-		constraintLogic: `${updatedTemplate.constraintLogic} and ${nextCode}`,
-		where: [
-			...updatedTemplate.where,
+		constraintLogic: updatedTemplate.constraintLogic,
+		where: updatedTemplate.where,
+	}
+
+	if (listConstraint.value.length > 0) {
+		const nextCode = CODES[updatedTemplate.where.length]
+		query.where = [
+			...query.where,
 			{
-				...listConstraintQuery,
+				...listConstraint,
 				path: classView,
-				values: listNames,
 				code: nextCode,
 			},
-		],
+		]
 	}
 
 	return (

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -8,6 +8,8 @@ import {
 import { sendToBus } from 'src/useMachineBus'
 import { assign, Machine } from 'xstate'
 
+import { listConstraintQuery } from '../common'
+
 /**
  *
  */
@@ -37,20 +39,26 @@ const setActiveQuery = assign({
 	isActiveQuery: (ctx, { query }) => query.name === ctx.template.name,
 })
 
-/**
- *
- */
 const addListConstraint = assign({
 	// @ts-ignore
-	listNames: (ctx, { listName }) => [...ctx.listNames, listName],
+	listConstraint: (ctx, { listName }) => {
+		return {
+			...ctx.listConstraint,
+			path: ctx.classView,
+			value: [listName],
+		}
+	},
 })
 
-/**
- *
- */
 const removeListConstraint = assign({
 	// @ts-ignore
-	listNames: (ctx, { listName }) => ctx.listNames.filter((list) => list !== listName),
+	listConstraint: (ctx) => {
+		return {
+			...ctx.listConstraint,
+			path: ctx.classView,
+			value: [],
+		}
+	},
 })
 
 /**
@@ -71,7 +79,7 @@ export const templateQueryMachine = (id = 'Template Query') =>
 			context: {
 				template: null,
 				isActiveQuery: false,
-				listNames: [],
+				listConstraint: listConstraintQuery,
 			},
 			states: {
 				idle: {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,7 +1,8 @@
 export const listConstraintQuery = {
 	path: '',
 	op: 'IN',
-	values: [],
+	value: [],
+	code: '',
 }
 
 export const CODES = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')


### PR DESCRIPTION
Currently the formatting for the lists has the list name placed in the
`values` prop of the query, but this keeps throwing errors. Instead, the
value should be placed in the `value` property since only 1 list can be
constrained per query.

This PR resolves multiple issues:

1. the lists not being properly formatted
2. allowing only 1 list to be selected
3. adding the list to the overview constraint query

Closes: #130
Closes: #131
Closes: #132