### PR TITLE
Persist api calls and search index to client storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"localforage": "^1.8.1",
 		"nanoid": "^3.1.10",
 		"nanoid-dictionary": "^3.0.0",
+		"object-hash": "^2.0.3",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"react-use": "^15.3.2",

--- a/src/caches.js
+++ b/src/caches.js
@@ -1,0 +1,29 @@
+import localForage from 'localforage'
+
+export const appCache = localForage.createInstance({
+	name: 'app',
+})
+
+export const pieChartCache = localForage.createInstance({
+	name: 'pie chart',
+})
+
+export const barChartCache = localForage.createInstance({
+	name: 'bar chart',
+})
+
+export const tableCache = localForage.createInstance({
+	name: 'table',
+})
+
+export const constraintValuesCache = localForage.createInstance({
+	name: 'constraint values',
+})
+
+export const templatesCache = localForage.createInstance({
+	name: 'templates',
+})
+
+export const searchIndexCache = localForage.createInstance({
+	name: 'search indexes',
+})

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -104,7 +104,7 @@ const TemplatesList = ({
 	)
 }
 
-const OverviewConstraintList = ({ queries, isLoading, mineName }) => {
+const OverviewConstraintList = ({ queries, isLoading }) => {
 	if (isLoading) {
 		return null
 	}
@@ -121,7 +121,6 @@ const OverviewConstraintList = ({ queries, isLoading, mineName }) => {
 					<OverviewConstraint
 						constraintConfig={config}
 						color={DATA_VIZ_COLORS[idx % DATA_VIZ_COLORS.length]}
-						mineName={mineName}
 					/>
 				</li>
 			))}
@@ -183,7 +182,7 @@ export const ConstraintSection = ({
 			) : (
 				<>
 					<QueryController />
-					<OverviewConstraintList queries={queries} isLoading={isLoading} mineName={mineName} />
+					<OverviewConstraintList queries={queries} isLoading={isLoading} />
 				</>
 			)}
 		</section>

--- a/src/components/Navigation/ClassSelector.jsx
+++ b/src/components/Navigation/ClassSelector.jsx
@@ -34,13 +34,13 @@ export const ClassSelector = ({ handleClassSelect, modelClasses, classView, mine
 					docId: 'name',
 					docField: 'displayName',
 					values: modelClasses,
-					cacheKey: `${mineName}-classSelector`,
+					query: { mineName, classView, modelClasses, name: `${mineName}-${classView}-classes` },
 				})
 			}
 		}
 
 		indexClasses()
-	}, [modelClasses, mineName])
+	}, [modelClasses, mineName, classView])
 
 	const filterQuery = (query, items) => {
 		if (query === '' || !classSearchIndex?.current) {

--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -56,7 +56,7 @@ const renderMenu = (selectedValue) => ({ filteredItems, itemsParentRef, query, r
 	)
 }
 
-export const ListSelector = ({ listsForCurrentClass, mineName }) => {
+export const ListSelector = ({ listsForCurrentClass, mineName, classView }) => {
 	const listSearchIndex = useRef(null)
 	const [selectedValue, setSelectedValue] = useState('')
 
@@ -67,13 +67,13 @@ export const ListSelector = ({ listsForCurrentClass, mineName }) => {
 					docId: 'listName',
 					docField: 'displayName',
 					values: listsForCurrentClass,
-					cacheKey: `${mineName}-listSelector`,
+					query: { listsForCurrentClass, mineName, name: `${mineName}-${classView}-lists` },
 				})
 			}
 		}
 
 		indexClasses()
-	}, [listsForCurrentClass, mineName])
+	}, [classView, listsForCurrentClass, mineName])
 
 	const filterQuery = (query, items) => {
 		if (query === '' || !listSearchIndex?.current) {

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -28,7 +28,11 @@ export const NavigationBar = () => {
 					classView={classView}
 					mineName={selectedMine.name}
 				/>
-				<ListSelector listsForCurrentClass={listsForCurrentClass} mineName={selectedMine.name} />
+				<ListSelector
+					listsForCurrentClass={listsForCurrentClass}
+					mineName={selectedMine.name}
+					classView={classView}
+				/>
 			</Navbar.Group>
 		</Navbar>
 	)

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -94,7 +94,7 @@ const S_ConstraintIcon = styled.div`
 	justify-content: center;
 `
 
-export const OverviewConstraint = ({ constraintConfig, color, mineName }) => {
+export const OverviewConstraint = ({ constraintConfig, color }) => {
 	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
 	const [state, send] = useMachineBus(
@@ -119,13 +119,16 @@ export const OverviewConstraint = ({ constraintConfig, color, mineName }) => {
 					docField,
 					docId: 'item',
 					values: availableValues,
-					cacheKey: `${mineName}-overview-${path}-values`,
+					query: {
+						...constraintItemsQuery,
+						name: `${name}-constraint`,
+					},
 				})
 			}
 		}
 
 		buildIndex()
-	}, [availableValues, mineName, path, type])
+	}, [availableValues, constraintItemsQuery, name, type])
 
 	let ConstraintWidget
 

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -38,13 +38,13 @@ const ConstraintWidget = ({ constraint, rootUrl, mineName }) => {
 					docField,
 					docId: 'value',
 					values: availableValues,
-					cacheKey: `${mineName}-template-${constraint.path}-values`,
+					query: { rootUrl, mineName, constraint, name: `${name}-constraint` },
 				})
 			}
 		}
 
 		buildIndex()
-	}, [availableValues, constraint.path, mineName])
+	}, [availableValues, constraint, mineName, name, rootUrl])
 
 	const Widget =
 		availableValues.length <= 10 && constraint.op === 'ONE OF' ? CheckboxWidget : SuggestWidget

--- a/src/searchIndex.worker.js
+++ b/src/searchIndex.worker.js
@@ -1,14 +1,24 @@
 /* eslint-disable no-restricted-globals */
 import FlexSearch from 'flexsearch'
 
-self.onmessage = (event) => {
-	const { values, indexConfig, exportConfig, callbackId } = event.data
+import { searchIndexCache } from './caches'
+
+self.onmessage = async (event) => {
+	const { values, indexConfig, exportConfig, callbackId, cacheKey, indexName } = event.data
 	// @ts-ignore
 	const index = new FlexSearch(indexConfig)
 
 	// @ts-ignore
 	index.add(values)
 
+	searchIndexCache.setItem(cacheKey, {
+		// @ts-ignore
+		index: index.export(exportConfig),
+		name: indexName,
+		date: Date.now(),
+	})
+
 	// @ts-ignore
-	self.postMessage({ callbackId, results: index.export(exportConfig) })
+	// self.postMessage({ callbackId, results: index.export(exportConfig) })
+	self.postMessage({ callbackId, hasBeenCached: true })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12875,6 +12875,7 @@ fsevents@^1.2.7:
     nanoid-dictionary: ^3.0.0
     node-sass: ^4.14.1
     node-sass-magic-importer: ^5.3.2
+    object-hash: ^2.0.3
     prettier: ^2.0.5
     prettier-plugin-package: ^1.0.0
     prop-types: ^15.7.2
@@ -16539,7 +16540,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-hash@npm:^2.0.1":
+"object-hash@npm:^2.0.1, object-hash@npm:^2.0.3":
   version: 2.0.3
   resolution: "object-hash@npm:2.0.3"
   checksum: e633ae67cd6c5f3cd52af5bef0fe7f25d597b415a6d92a601be0b97a47642908cf333cedfc9e848d25b6c51fd6cf6e64ff6eb3af710eae249a42f6a69ad6b12d


### PR DESCRIPTION
Api calls can potentially be slow, and practically each major component
makes one to display data. By caching the retrieved results, we improve
the user experience. The same goes for search indexes, which can be
expensive to build.

This PR introduces client side storage using indexeddb, handled by
the `localforage` package. Caches are saved by namespaces and have a
last saved date attribute to assist with expiring the cache in a future
story. Each cache's key is a hash of its corresponding query object. This
way should any other component require the same value, no network calls
need to be made.

Closes: #134