### PR TITLE
Decrease the size of search indexes saved in client storage

### DIFF
--- a/src/searchIndex.js
+++ b/src/searchIndex.js
@@ -9,12 +9,12 @@ class SearchIndex {
 
 		this._worker.onerror = (event) => {
 			const { callbackId, error } = event.data
-			this._updateCallbacks({ callbackId, error, hasBeenCached: false })
+			this._updateCallbacks({ callbackId, error, exportedDocs: {} })
 		}
 
 		this._worker.onmessage = (event) => {
-			const { callbackId, hasBeenCached } = event.data
-			this._updateCallbacks({ callbackId, hasBeenCached, error: null })
+			const { callbackId, exportedDocs } = event.data
+			this._updateCallbacks({ callbackId, exportedDocs, error: null })
 		}
 	}
 
@@ -25,7 +25,7 @@ class SearchIndex {
 				callbackId,
 				resolve,
 				reject,
-				hasBeenCached: false,
+				exportedDocs: {},
 				error: null,
 				complete: false,
 			}
@@ -43,10 +43,10 @@ class SearchIndex {
 		})
 	}
 
-	_updateCallbacks({ callbackId, hasBeenCached, error }) {
+	_updateCallbacks({ callbackId, exportedDocs, error }) {
 		const target = this._callbacks.get(callbackId)
 		target.complete = true
-		target.hasBeenCached = hasBeenCached
+		target.exportedDocs = exportedDocs
 		target.error = error
 
 		this._callbacks.forEach((data, key) => {
@@ -59,7 +59,7 @@ class SearchIndex {
 			if (data.error) {
 				data.reject(data.error)
 			} else {
-				data.resolve(data.hasBeenCached)
+				data.resolve(data.exportedDocs)
 			}
 		})
 	}

--- a/src/searchIndex.worker.js
+++ b/src/searchIndex.worker.js
@@ -5,20 +5,32 @@ import { searchIndexCache } from './caches'
 
 self.onmessage = async (event) => {
 	const { values, indexConfig, exportConfig, callbackId, cacheKey, indexName } = event.data
-	// @ts-ignore
-	const index = new FlexSearch(indexConfig)
 
-	// @ts-ignore
-	index.add(values)
+	const exportedDocs = {}
 
-	searchIndexCache.setItem(cacheKey, {
+	for (const val of values) {
+		exportedDocs[val[indexConfig.doc.id]] = val
+	}
+
+	const cachedIndex = await searchIndexCache.getItem(cacheKey)
+	if (!cachedIndex) {
 		// @ts-ignore
-		index: index.export(exportConfig),
-		name: indexName,
-		date: Date.now(),
-	})
+		const index = new FlexSearch(indexConfig)
+
+		// @ts-ignore
+		index.add(values)
+
+		await searchIndexCache.setItem(cacheKey, {
+			// @ts-ignore
+			index: index.export(exportConfig),
+			name: indexName,
+			date: Date.now(),
+		})
+	}
 
 	// @ts-ignore
-	// self.postMessage({ callbackId, results: index.export(exportConfig) })
-	self.postMessage({ callbackId, hasBeenCached: true })
+	self.postMessage({
+		callbackId,
+		exportedDocs,
+	})
 }


### PR DESCRIPTION
The size of the indexes was too large because we were storing the docs
along with the index. One index was storing around 250mb. This PR
saves just the index to the client storage.

Closes: #136

Squashed commits:
* Save just the index to client storage
* Only build index if none exists
