### PR TITLE
Lift machines up the tree to allow fetching data before they mount

### DIFF
--- a/src/apiRequests.js
+++ b/src/apiRequests.js
@@ -15,6 +15,8 @@ const getService = (rootUrl) => {
 	return service
 }
 
+export const INTERMINE_REGISTRY = 'https://registry.intermine.org/service/instances'
+
 export const fetchSummary = async ({ rootUrl, query, path }) => {
 	const service = getService(rootUrl)
 	const q = new imjs.Query(query, service)
@@ -52,8 +54,8 @@ export const fetchTemplates = async ({ rootUrl }) => {
 	return await service.fetchTemplates()
 }
 
-export const fetchInstances = async () => {
-	return axios.get('https://registry.intermine.org/service/instances', {
+export const fetchInstances = async (registry) => {
+	return axios.get(registry, {
 		params: {
 			mine: 'prod',
 		},

--- a/src/caches.js
+++ b/src/caches.js
@@ -27,3 +27,7 @@ export const templatesCache = localForage.createInstance({
 export const searchIndexCache = localForage.createInstance({
 	name: 'search indexes',
 })
+
+export const interminesConfigCache = localForage.createInstance({
+	name: 'intermines',
+})

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,7 +4,7 @@ import '@emotion/core'
 import { Card } from '@blueprintjs/core'
 import { enableMapSet } from 'immer'
 import React, { useEffect } from 'react'
-import { FETCH_INITIAL_SUMMARY, TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
+import { FETCH_INITIAL_SUMMARY, FETCH_TEMPLATES } from 'src/eventConstants'
 import { AppManagerServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
 
 import logo from '../../images/logo.png'
@@ -20,27 +20,14 @@ enableMapSet()
 export const App = () => {
 	const [state, send] = useMachineBus(appManagerMachine)
 
-	const {
-		appView,
-		classView,
-		possibleQueries,
-		categories,
-		selectedMine,
-		showAllLabel,
-		viewIsLoading,
-	} = state.context
+	const { appView, classView, overviewQueries, selectedMine, viewActors } = state.context
 
 	const rootUrl = selectedMine.rootUrl
 
 	useEffect(() => {
-		if (state.matches('defaultView')) {
-			sendToBus({ type: FETCH_INITIAL_SUMMARY, globalConfig: { rootUrl, classView } })
-		}
-	}, [rootUrl, classView, state])
-
-	const toggleCategory = ({ isVisible, tagName }) => {
-		send({ type: TOGGLE_CATEGORY_VISIBILITY, isVisible, tagName })
-	}
+		send({ type: FETCH_TEMPLATES })
+		sendToBus({ type: FETCH_INITIAL_SUMMARY, classView, rootUrl })
+	}, [classView, rootUrl, selectedMine, send])
 
 	return (
 		<div className="light-theme">
@@ -64,16 +51,11 @@ export const App = () => {
 			</AppManagerServiceContext.Provider>
 			<main css={{ display: 'grid', gridTemplateColumns: '230px 1fr' }}>
 				<ConstraintSection
-					queries={possibleQueries}
+					templateViewActor={viewActors.templateView}
 					view={appView}
-					classCategoryTags={Object.values(categories)}
-					isLoading={viewIsLoading}
-					toggleCategory={toggleCategory}
-					showAllLabel={showAllLabel}
 					classView={classView}
 					rootUrl={rootUrl}
-					showAll={categories[showAllLabel]?.isVisible ?? true}
-					mineName={selectedMine.name}
+					overviewQueries={overviewQueries}
 				/>
 				<section
 					id="data-viz"

--- a/src/components/App/fetchMineConfigUtils.js
+++ b/src/components/App/fetchMineConfigUtils.js
@@ -1,0 +1,27 @@
+import { fetchClasses, fetchInstances, fetchLists } from 'src/apiRequests'
+
+export const interminesPromise = (cachedIntermines, registry) =>
+	cachedIntermines ? Promise.resolve(cachedIntermines.intermines) : fetchInstances(registry)
+
+export const modelClassesPromise = (cachedModelClasses, rootUrl) =>
+	cachedModelClasses ? Promise.resolve(cachedModelClasses.modelClasses) : fetchClasses(rootUrl)
+
+export const listsPromise = (cachedLists, rootUrl) =>
+	cachedLists ? Promise.resolve(cachedLists.lists) : fetchLists(rootUrl)
+
+export const interminesConfig = (interminesResp) =>
+	interminesResp.data.instances.map((mine) => ({
+		name: mine.name,
+		rootUrl: mine.url,
+	}))
+
+export const modelClassesConfig = (modelClassesResp) =>
+	Object.entries(modelClassesResp.classes)
+		.map(([_key, value]) => ({
+			displayName: value.displayName,
+			name: value.name,
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name))
+
+export const listsConfig = (listsResp) =>
+	listsResp.map(({ name, title, type }) => ({ name, title, type }))

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -74,7 +74,7 @@ export const BarChartMachine = Machine(
 			},
 		},
 		services: {
-			fetchGeneLength: async (_ctx, { globalConfig: { classView, rootUrl }, query: nextQuery }) => {
+			fetchGeneLength: async (_ctx, { classView, rootUrl, query: nextQuery }) => {
 				let query = {
 					...nextQuery,
 					from: classView,

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -94,7 +94,7 @@ const S_ConstraintIcon = styled.div`
 	justify-content: center;
 `
 
-export const OverviewConstraint = ({ constraintConfig, color }) => {
+export const OverviewConstraint = ({ constraintConfig, color, classView, rootUrl }) => {
 	const { type, name, label, path, op, valuesQuery: constraintItemsQuery } = constraintConfig
 
 	const [state, send] = useMachineBus(
@@ -104,6 +104,8 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 			type,
 			constraintPath: path,
 			constraintItemsQuery,
+			classView,
+			rootUrl,
 		})
 	)
 
@@ -139,10 +141,6 @@ export const OverviewConstraint = ({ constraintConfig, color }) => {
 		default:
 			ConstraintWidget = SuggestWidget
 			break
-	}
-
-	if (state.matches('noConstraintItems') || state.matches('loading')) {
-		return null
 	}
 
 	/**

--- a/src/components/Overview/overviewConstraintMachine.js
+++ b/src/components/Overview/overviewConstraintMachine.js
@@ -6,7 +6,6 @@ import {
 	APPLY_DATA_BROWSER_CONSTRAINT,
 	APPLY_OVERVIEW_CONSTRAINT_TO_QUERY,
 	DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY,
-	FETCH_INITIAL_SUMMARY,
 	LOCK_ALL_CONSTRAINTS,
 	REMOVE_CONSTRAINT,
 	RESET_ALL_CONSTRAINTS,
@@ -77,7 +76,7 @@ export const overviewConstraintMachine = (id) =>
 	Machine(
 		{
 			id: `${id} constraint machine`,
-			initial: 'noConstraintsSet',
+			initial: 'loading',
 			context: {
 				type: '',
 				op: '',
@@ -93,7 +92,6 @@ export const overviewConstraintMachine = (id) =>
 				[RESET_ALL_CONSTRAINTS]: { target: 'noConstraintsSet', actions: 'removeAll' },
 				[RESET_LOCAL_CONSTRAINT]: { target: 'noConstraintsSet', actions: 'removeAll' },
 				[UNSET_CONSTRAINT]: { target: 'constraintsUpdated', cond: 'pathMatches' },
-				[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
 			},
 			states: {
 				loading: {
@@ -177,9 +175,8 @@ export const overviewConstraintMachine = (id) =>
 				fetchInitialValues: async (ctx, event) => {
 					const { constraintItemsQuery, constraintPath } = ctx
 
-					const {
-						globalConfig: { rootUrl, classView },
-					} = event
+					const rootUrl = event?.rootUrl ?? ctx.rootUrl
+					const classView = event?.classView ?? ctx.classView
 
 					const query = {
 						...constraintItemsQuery,

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -61,10 +61,7 @@ export const PieChartMachine = Machine(
 		},
 		services: {
 			fetchItems: async (_ctx, event) => {
-				const {
-					globalConfig: { classView, rootUrl },
-					query: nextQuery,
-				} = event
+				const { classView, rootUrl, query: nextQuery } = event
 
 				let query = {
 					...nextQuery,

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -110,7 +110,7 @@ export const QueryController = () => {
 			where: codedConstraints,
 		}
 
-		sendToBus({ type: FETCH_UPDATED_SUMMARY, query, globalConfig: { classView, rootUrl } })
+		sendToBus({ type: FETCH_UPDATED_SUMMARY, query, classView, rootUrl })
 	}
 
 	const handleDeleteConstraint = (path) => {

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -17,9 +17,9 @@ const initializeMachine = assign({
 	currentConstraints: () => [],
 	selectedPaths: () => [],
 	// @ts-ignore
-	classView: (_, { globalConfig }) => globalConfig.classView,
+	classView: (_, { classView }) => classView,
 	// @ts-ignore
-	rootUrl: (_, { globalConfig }) => globalConfig.rootUrl,
+	rootUrl: (_, { rootUrl }) => rootUrl,
 })
 
 const addConstraint = assign({
@@ -105,7 +105,6 @@ export const queryControllerMachine = Machine(
 			[FETCH_INITIAL_SUMMARY]: {
 				target: 'idle',
 				actions: 'initializeMachine',
-				cond: 'isInitialFetch',
 			},
 		},
 		states: {

--- a/src/components/Table/tableMachine.js
+++ b/src/components/Table/tableMachine.js
@@ -150,8 +150,7 @@ export const TableChartMachine = Machine(
 			},
 		},
 		services: {
-			fetchInitialRows: async (ctx, { globalConfig, query: maybeQuery }) => {
-				const { classView, rootUrl } = globalConfig
+			fetchInitialRows: async (ctx, { classView, rootUrl, query: maybeQuery }) => {
 				const query = maybeQuery
 					? maybeQuery
 					: {

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -46,6 +46,7 @@ export const TOGGLE_VIEW_IS_LOADING = 'appManager/view/isLoading'
 export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 export const SET_API_TOKEN = 'appManager/api/token'
+export const FETCH_TEMPLATES = 'appManager/fetch/templates'
 
 /**
  * Table

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,7 +56,8 @@ export type ConstraintEvents = EventObject &
 		| {
 				to?: string
 				type: typeof SET_INITIAL_ORGANISMS
-				globalConfig: { rootUrl: string; classView: string }
+				rootUrl: string
+				classView: string
 		  }
 	)
 


### PR DESCRIPTION
Some components need to fetch data before being mounted. To do this, this
PR will spawn actors. Doing so allows the parent machine to control
the lifecycle of that actor, and therefore it can start and fetch data
when the parent instantiates it.

Closes: #138 