### PR TITLE
Render overview constraints with spawned actors

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,7 +4,11 @@ import '@emotion/core'
 import { Card } from '@blueprintjs/core'
 import { enableMapSet } from 'immer'
 import React, { useEffect } from 'react'
-import { FETCH_INITIAL_SUMMARY, FETCH_TEMPLATES } from 'src/eventConstants'
+import {
+	FETCH_INITIAL_SUMMARY,
+	FETCH_OVERVIEW_CONSTRAINTS,
+	FETCH_TEMPLATES,
+} from 'src/eventConstants'
 import { AppManagerServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
 
 import logo from '../../images/logo.png'
@@ -20,11 +24,12 @@ enableMapSet()
 export const App = () => {
 	const [state, send] = useMachineBus(appManagerMachine)
 
-	const { appView, classView, overviewQueries, selectedMine, viewActors } = state.context
+	const { appView, classView, selectedMine, viewActors } = state.context
 
 	const rootUrl = selectedMine.rootUrl
 
 	useEffect(() => {
+		send({ type: FETCH_OVERVIEW_CONSTRAINTS })
 		send({ type: FETCH_TEMPLATES })
 		sendToBus({ type: FETCH_INITIAL_SUMMARY, classView, rootUrl })
 	}, [classView, rootUrl, selectedMine, send])
@@ -52,10 +57,8 @@ export const App = () => {
 			<main css={{ display: 'grid', gridTemplateColumns: '230px 1fr' }}>
 				<ConstraintSection
 					templateViewActor={viewActors.templateView}
+					overviewActor={viewActors.overview}
 					view={appView}
-					classView={classView}
-					rootUrl={rootUrl}
-					overviewQueries={overviewQueries}
 				/>
 				<section
 					id="data-viz"

--- a/src/components/App/overviewMachine.js
+++ b/src/components/App/overviewMachine.js
@@ -1,0 +1,106 @@
+import { assign, Machine, sendUpdate, spawn } from 'xstate'
+
+import { overviewConstraintMachine } from '../Overview/overviewConstraintMachine'
+
+/** @type {import('../../types').ConstraintConfig[]} */
+const defaultQueries = [
+	{
+		type: 'checkbox',
+		name: 'Organism',
+		label: 'Or',
+		path: 'organism.shortName',
+		op: 'ONE OF',
+		valuesQuery: {
+			select: ['primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			where: [],
+		},
+	},
+	{
+		type: 'select',
+		name: 'Pathway Name',
+		label: 'Pn',
+		path: 'pathways.name',
+		op: 'ONE OF',
+		valuesQuery: {
+			select: ['pathways.name', 'primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			orderBy: [
+				{
+					path: 'pathways.name',
+					direction: 'ASC',
+				},
+			],
+		},
+	},
+	{
+		type: 'select',
+		name: 'GO Annotation',
+		label: 'GA',
+		path: 'goAnnotation.ontologyTerm.name',
+		op: 'ONE OF',
+		valuesQuery: {
+			select: ['goAnnotation.ontologyTerm.name', 'primaryIdentifier'],
+			model: {
+				name: 'genomic',
+			},
+			orderBy: [
+				{
+					path: 'Gene.goAnnotation.ontologyTerm.name',
+					direction: 'ASC',
+				},
+			],
+		},
+	},
+]
+
+/**
+ *
+ */
+const spawnConstraintActors = assign({
+	constraintActors: (ctx) => {
+		return ctx.constraints.map(({ type, name, label, path, op, valuesQuery }) => {
+			const constraintActor = overviewConstraintMachine.withContext({
+				...overviewConstraintMachine.context,
+				op,
+				type,
+				label,
+				name,
+				constraintPath: path,
+				constraintItemsQuery: valuesQuery,
+				classView: ctx.classView,
+				rootUrl: ctx.rootUrl,
+			})
+
+			return spawn(constraintActor, `${name} overview constraint machine`)
+		})
+	},
+})
+
+export const overviewMachine = Machine(
+	{
+		id: 'overview',
+		initial: 'idle',
+		context: {
+			constraints: defaultQueries,
+			constraintActors: [],
+			classView: '',
+			rootUrl: '',
+		},
+		states: {
+			idle: {
+				entry: ['spawnConstraintActors', 'sendUpdate'],
+			},
+		},
+	},
+	{
+		actions: {
+			spawnConstraintActors,
+			sendUpdate,
+		},
+	}
+)

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -112,7 +112,10 @@ const TemplatesList = ({ templateViewActor }) => {
 	)
 }
 
-const OverviewConstraintList = ({ queries, classView, rootUrl }) => {
+const OverviewConstraintList = ({ overviewActor }) => {
+	const [state] = useService(overviewActor)
+	const { constraintActors } = state.context
+
 	return (
 		<ul
 			css={{
@@ -121,27 +124,21 @@ const OverviewConstraintList = ({ queries, classView, rootUrl }) => {
 				padding: 0,
 			}}
 		>
-			{queries.map((config, idx) => (
-				<li css={{ margin: '0.875em 0' }} key={idx}>
-					<OverviewConstraint
-						constraintConfig={config}
-						color={DATA_VIZ_COLORS[idx % DATA_VIZ_COLORS.length]}
-						classView={classView}
-						rootUrl={rootUrl}
-					/>
-				</li>
-			))}
+			{constraintActors.map((actor, idx) => {
+				return (
+					<li css={{ margin: '0.875em 0' }} key={actor.id}>
+						<OverviewConstraint
+							overviewConstraintActor={actor}
+							color={DATA_VIZ_COLORS[idx % DATA_VIZ_COLORS.length]}
+						/>
+					</li>
+				)
+			})}
 		</ul>
 	)
 }
 
-export const ConstraintSection = ({
-	view,
-	classView,
-	rootUrl,
-	templateViewActor,
-	overviewQueries,
-}) => {
+export const ConstraintSection = ({ view, templateViewActor, overviewActor }) => {
 	const isTemplateView = view === 'templateView'
 
 	return (
@@ -165,16 +162,12 @@ export const ConstraintSection = ({
 				<Tab id="defaultView" title="Overview" />
 				<Tab id="templateView" title="Templates" />
 			</Tabs>
-			{isTemplateView ? (
+			{isTemplateView && templateViewActor ? (
 				<TemplatesList templateViewActor={templateViewActor} />
 			) : (
 				<>
 					<QueryController />
-					<OverviewConstraintList
-						queries={overviewQueries}
-						classView={classView}
-						rootUrl={rootUrl}
-					/>
+					{overviewActor && <OverviewConstraintList overviewActor={overviewActor} />}
 				</>
 			)}
 		</section>

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -47,6 +47,7 @@ export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 export const SET_API_TOKEN = 'appManager/api/token'
 export const FETCH_TEMPLATES = 'appManager/fetch/templates'
+export const FETCH_OVERVIEW_CONSTRAINTS = 'appManager/fetch/overviewConstraints'
 
 /**
  * Table


### PR DESCRIPTION
Because we no longer were updating the overview constraints with an event
bus action, they would not refresh when the mine or class view changed.
This commit renders the overview constraints as spawned actors whenever
the mine or class changes.

This commit also ensures that previous spawned actors are stopped, so that
they can no longer receive events and transition.

Closes: #140 