### PR TITLE
Maintain the query controller state between constraint views

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -2,14 +2,16 @@
 import '@emotion/core'
 
 import { Card } from '@blueprintjs/core'
+import { useMachine } from '@xstate/react'
 import { enableMapSet } from 'immer'
 import React, { useEffect } from 'react'
 import {
 	FETCH_INITIAL_SUMMARY,
 	FETCH_OVERVIEW_CONSTRAINTS,
 	FETCH_TEMPLATES,
+	RESET_QUERY_CONTROLLER,
 } from 'src/eventConstants'
-import { AppManagerServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
+import { AppManagerServiceContext, useEventBus } from 'src/useEventBus'
 
 import logo from '../../images/logo.png'
 import { BarChart } from '../BarChart/BarChart'
@@ -22,17 +24,19 @@ import { appManagerMachine } from './appManagerMachine'
 enableMapSet()
 
 export const App = () => {
-	const [state, send] = useMachineBus(appManagerMachine)
+	const [state, send, service] = useMachine(appManagerMachine)
+	const [sendToBus] = useEventBus(service)
 
-	const { appView, classView, selectedMine, viewActors } = state.context
+	const { classView, selectedMine, viewActors } = state.context
 
 	const rootUrl = selectedMine.rootUrl
 
 	useEffect(() => {
 		send({ type: FETCH_OVERVIEW_CONSTRAINTS })
 		send({ type: FETCH_TEMPLATES })
+		send({ type: RESET_QUERY_CONTROLLER })
 		sendToBus({ type: FETCH_INITIAL_SUMMARY, classView, rootUrl })
-	}, [classView, rootUrl, selectedMine, send])
+	}, [classView, rootUrl, selectedMine, send, sendToBus])
 
 	return (
 		<div className="light-theme">
@@ -58,7 +62,7 @@ export const App = () => {
 				<ConstraintSection
 					templateViewActor={viewActors.templateView}
 					overviewActor={viewActors.overview}
-					view={appView}
+					queryControllerActor={viewActors.queryController}
 				/>
 				<section
 					id="data-viz"

--- a/src/components/App/overviewMachine.js
+++ b/src/components/App/overviewMachine.js
@@ -1,4 +1,4 @@
-import { assign, Machine, sendUpdate, spawn } from 'xstate'
+import { assign, Machine, spawn } from 'xstate'
 
 import { overviewConstraintMachine } from '../Overview/overviewConstraintMachine'
 
@@ -93,14 +93,13 @@ export const overviewMachine = Machine(
 		},
 		states: {
 			idle: {
-				entry: ['spawnConstraintActors', 'sendUpdate'],
+				entry: 'spawnConstraintActors',
 			},
 		},
 	},
 	{
 		actions: {
 			spawnConstraintActors,
-			sendUpdate,
 		},
 	}
 )

--- a/src/components/App/templateViewMachine.js
+++ b/src/components/App/templateViewMachine.js
@@ -3,7 +3,7 @@ import { fetchTemplates } from 'src/apiRequests'
 import { templatesCache } from 'src/caches'
 import { CHANGE_CLASS, TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
 import { getTagCategories } from 'src/utils'
-import { assign, Machine, sendUpdate } from 'xstate'
+import { assign, Machine } from 'xstate'
 
 /**
  *
@@ -202,21 +202,15 @@ export const templateViewMachine = Machine(
 							'setCategoriesForClass',
 							'filterTemplatesForClassView',
 							'filterBySelectedCategory',
-							'sendUpdate',
 						],
 					},
 					[TOGGLE_CATEGORY_VISIBILITY]: [
 						{
 							cond: 'showAllClicked',
-							actions: ['toggleCategory', 'filterBySelectedCategory', 'sendUpdate'],
+							actions: ['toggleCategory', 'filterBySelectedCategory'],
 						},
 						{
-							actions: [
-								'disableShowAllTag',
-								'toggleCategory',
-								'filterBySelectedCategory',
-								'sendUpdate',
-							],
+							actions: ['disableShowAllTag', 'toggleCategory', 'filterBySelectedCategory'],
 						},
 					],
 				},
@@ -234,7 +228,6 @@ export const templateViewMachine = Machine(
 							'setCategoriesForClass',
 							'filterTemplatesForClassView',
 							'filterBySelectedCategory',
-							'sendUpdate',
 						],
 					},
 					onError: {
@@ -257,7 +250,6 @@ export const templateViewMachine = Machine(
 			setTemplates,
 			toggleCategory,
 			updateClassView,
-			sendUpdate,
 		},
 		guards: {
 			// @ts-ignore

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -1,4 +1,5 @@
 import { ProgressBar } from '@blueprintjs/core'
+import { useMachine } from '@xstate/react'
 import React from 'react'
 // use direct import because babel is not properly changing it in webpack
 import { useFirstMountState } from 'react-use/lib/useFirstMountState'
@@ -14,7 +15,7 @@ import {
 	XAxis,
 } from 'recharts'
 import { blinkingSkeletonAnimation } from 'src/styleUtils'
-import { useMachineBus } from 'src/useMachineBus'
+import { useEventBus } from 'src/useEventBus'
 import { barChartLoadingData } from 'src/utils/loadingData/barChartData'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
@@ -56,7 +57,8 @@ const colorizeBars = (data, isLoading) =>
 
 export const BarChart = React.memo(function BarChart() {
 	const isFirstRender = useFirstMountState()
-	const [state] = useMachineBus(BarChartMachine)
+	const [state, , service] = useMachine(BarChartMachine)
+	useEventBus(service)
 
 	const { lengthSummary, lengthStats } = state.context
 

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -3,8 +3,7 @@ import { IconNames } from '@blueprintjs/icons'
 import { useService } from '@xstate/react'
 import React, { useState } from 'react'
 import { useWindowSize } from 'react-use'
-import { CHANGE_CONSTRAINT_VIEW, TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
 import { OverviewConstraint } from '../Overview/OverviewConstraint'
@@ -144,7 +143,8 @@ const OverviewConstraintList = ({ overviewActor }) => {
 	)
 }
 
-export const ConstraintSection = ({ view, templateViewActor, overviewActor }) => {
+export const ConstraintSection = ({ templateViewActor, overviewActor, queryControllerActor }) => {
+	const [view, setView] = useState('defaultAppView')
 	const isTemplateView = view === 'templateView'
 
 	return (
@@ -159,7 +159,8 @@ export const ConstraintSection = ({ view, templateViewActor, overviewActor }) =>
 				id="constraint-tabs"
 				selectedTabId={view}
 				large={true}
-				onChange={(newTabId) => sendToBus({ type: CHANGE_CONSTRAINT_VIEW, newTabId })}
+				// @ts-ignore
+				onChange={setView}
 				css={{
 					marginBottom: 10,
 					[`&& .${Classes.TAB_LIST}`]: { margin: '10px 20px 0' },
@@ -172,7 +173,7 @@ export const ConstraintSection = ({ view, templateViewActor, overviewActor }) =>
 				<TemplatesList templateViewActor={templateViewActor} />
 			) : (
 				<>
-					<QueryController />
+					{queryControllerActor && <QueryController queryControllerActor={queryControllerActor} />}
 					{overviewActor && <OverviewConstraintList overviewActor={overviewActor} />}
 				</>
 			)}

--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -4,7 +4,7 @@ import { Select } from '@blueprintjs/select'
 import React, { useEffect, useRef, useState } from 'react'
 import { buildSearchIndex } from 'src/buildSearchIndex'
 import { ADD_LIST_CONSTRAINT, REMOVE_LIST_CONSTRAINT } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { useEventBus } from 'src/useEventBus'
 import { pluralizeFilteredCount } from 'src/utils'
 
 import { ConstraintSetTag } from '../Shared/ConstraintSetTag'
@@ -59,6 +59,7 @@ const renderMenu = (selectedValue) => ({ filteredItems, itemsParentRef, query, r
 export const ListSelector = ({ listsForCurrentClass, mineName, classView }) => {
 	const listSearchIndex = useRef(null)
 	const [selectedValue, setSelectedValue] = useState('')
+	const [sendToBus] = useEventBus()
 
 	useEffect(() => {
 		const indexClasses = async () => {

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
 import React, { useEffect, useState } from 'react'
 import { CHANGE_MINE, SET_API_TOKEN } from 'src/eventConstants'
-import { useServiceContext } from 'src/useMachineBus'
+import { useServiceContext } from 'src/useEventBus'
 
 import { NumberedSelectMenuItems } from '../Shared/Selects'
 

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -1,7 +1,7 @@
 import { Navbar } from '@blueprintjs/core'
 import React from 'react'
 import { CHANGE_CLASS } from 'src/eventConstants'
-import { useServiceContext } from 'src/useMachineBus'
+import { useServiceContext } from 'src/useEventBus'
 
 import { ClassSelector } from './ClassSelector'
 import { ListSelector } from './ListSelector'

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useRef } from 'react'
 import { buildSearchIndex } from 'src/buildSearchIndex'
 import { APPLY_DATA_BROWSER_CONSTRAINT, RESET_LOCAL_CONSTRAINT } from 'src/eventConstants'
-import { ConstraintServiceContext } from 'src/useMachineBus'
+import { ConstraintServiceContext } from 'src/useEventBus'
 
 import { ConstraintSetTag } from '../Shared/ConstraintSetTag'
 import { PopupCard } from '../Shared/PopupCard'

--- a/src/components/Overview/overviewConstraintMachine.js
+++ b/src/components/Overview/overviewConstraintMachine.js
@@ -12,9 +12,9 @@ import {
 	RESET_LOCAL_CONSTRAINT,
 	UNSET_CONSTRAINT,
 } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { sendToBus } from 'src/useEventBus'
 import { formatConstraintPath } from 'src/utils'
-import { assign, Machine, sendUpdate } from 'xstate'
+import { assign, Machine } from 'xstate'
 
 import { logErrorToConsole } from '../../utils'
 
@@ -101,7 +101,7 @@ export const overviewConstraintMachine = Machine(
 					src: 'fetchInitialValues',
 					onDone: {
 						target: 'noConstraintsSet',
-						actions: ['setAvailableValues', 'sendUpdate'],
+						actions: 'setAvailableValues',
 					},
 					onError: {
 						target: 'noConstraintItems',
@@ -159,7 +159,6 @@ export const overviewConstraintMachine = Machine(
 			setAvailableValues,
 			applyOverviewConstraint,
 			resetConstraint,
-			sendUpdate,
 		},
 		guards: {
 			selectedListIsEmpty: (ctx) => {

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -1,4 +1,5 @@
 import { ProgressBar } from '@blueprintjs/core'
+import { useMachine } from '@xstate/react'
 import React from 'react'
 // use direct import because babel is not properly changing it in webpack
 import { useFirstMountState } from 'react-use/lib/useFirstMountState'
@@ -13,7 +14,7 @@ import {
 	Tooltip,
 } from 'recharts'
 import { blinkingSkeletonAnimation } from 'src/styleUtils'
-import { useMachineBus } from 'src/useMachineBus'
+import { useEventBus } from 'src/useEventBus'
 import { pieChartLoadingData } from 'src/utils/loadingData/pieChartData'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
@@ -62,7 +63,9 @@ const renderLoadingLabel = (props) => {
 
 export const PieChart = React.memo(function PieChart() {
 	const isFirstRender = useFirstMountState()
-	const [state] = useMachineBus(PieChartMachine)
+	const [state, , service] = useMachine(PieChartMachine)
+	useEventBus(service)
+
 	const { allClassOrganisms, classView } = state.context
 
 	const isLoading = !state.matches('idle')

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -1,15 +1,15 @@
 import { Button, Divider, H4, H5, NonIdealState } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
+import { useService } from '@xstate/react'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DELETE_QUERY_CONSTRAINT, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
-import { QueryServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
+import { QueryServiceContext, useEventBus } from 'src/useEventBus'
 
 import { CODES } from '../common'
 import { RunQueryButton } from '../Shared/Buttons'
 import { NonIdealStateWarning } from '../Shared/NonIdealStates'
 import { PopupCard } from '../Shared/PopupCard'
-import { queryControllerMachine } from './queryControllerMachine'
 
 const getOperantSymbol = (operant) => {
 	switch (operant) {
@@ -74,8 +74,9 @@ CurrentConstraints.defaultProps = {
 	currentConstraints: [],
 }
 
-export const QueryController = () => {
-	const [state, send] = useMachineBus(queryControllerMachine)
+export const QueryController = ({ queryControllerActor }) => {
+	const [state, send, service] = useService(queryControllerActor)
+	const [sendToBus] = useEventBus(service)
 
 	const { currentConstraints, classView, selectedPaths, rootUrl, listConstraint } = state.context
 
@@ -114,6 +115,7 @@ export const QueryController = () => {
 	}
 
 	const handleDeleteConstraint = (path) => {
+		// @ts-ignore
 		send({ type: DELETE_QUERY_CONSTRAINT, path })
 	}
 

--- a/src/components/QueryController/queryControllerMachine.js
+++ b/src/components/QueryController/queryControllerMachine.js
@@ -3,12 +3,11 @@ import {
 	APPLY_OVERVIEW_CONSTRAINT_TO_QUERY,
 	DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY,
 	DELETE_QUERY_CONSTRAINT,
-	FETCH_INITIAL_SUMMARY,
 	REMOVE_LIST_CONSTRAINT,
 	SET_AVAILABLE_COLUMNS,
 	UNSET_CONSTRAINT,
 } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { sendToBus } from 'src/useEventBus'
 import { assign, Machine } from 'xstate'
 
 import { listConstraintQuery } from '../common'
@@ -102,10 +101,6 @@ export const queryControllerMachine = Machine(
 			[SET_AVAILABLE_COLUMNS]: { actions: 'setSelectedPaths' },
 			[DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY]: { target: 'idle', actions: 'removeConstraint' },
 			[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
-			[FETCH_INITIAL_SUMMARY]: {
-				target: 'idle',
-				actions: 'initializeMachine',
-			},
 		},
 		states: {
 			idle: {

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -12,12 +12,13 @@ import {
 } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
+import { useMachine } from '@xstate/react'
 import React, { useEffect, useState } from 'react'
 import { useDebounce } from 'react-use'
 // use direct import because babel is not properly changing it in webpack
 import { useFirstMountState } from 'react-use/lib/useFirstMountState'
 import { CHANGE_PAGE } from 'src/eventConstants'
-import { TableServiceContext, useMachineBus, useServiceContext } from 'src/useMachineBus'
+import { TableServiceContext, useEventBus, useServiceContext } from 'src/useEventBus'
 import { tableLoadingData } from 'src/utils/loadingData/tableResults'
 import { humanize, titleize } from 'underscore.string'
 
@@ -219,7 +220,8 @@ const Cell = ({ cell, mineUrl, isLoading }) => {
  */
 export const Table = React.memo(function Table() {
 	const isFirstRender = useFirstMountState()
-	const [state, send] = useMachineBus(TableChartMachine)
+	const [state, send, service] = useMachine(TableChartMachine)
+	useEventBus(service)
 
 	const { pages, mineUrl, totalRows, pageNumber, visibleRows } = state.context
 	const isLoading = !state.matches('idle')

--- a/src/components/Table/tableMachine.js
+++ b/src/components/Table/tableMachine.js
@@ -7,7 +7,7 @@ import {
 	FETCH_UPDATED_SUMMARY,
 	SET_AVAILABLE_COLUMNS,
 } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { sendToBus } from 'src/useEventBus'
 import { assign, Machine } from 'xstate'
 
 const bustCachedPages = assign({

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -1,10 +1,10 @@
 import { Button, Classes, Divider, H5, Icon } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
-import { useService } from '@xstate/react'
+import { useMachine, useService } from '@xstate/react'
 import React, { useEffect, useRef } from 'react'
 import { buildSearchIndex } from 'src/buildSearchIndex'
 import { FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
-import { ConstraintServiceContext, sendToBus, useMachineBus } from 'src/useMachineBus'
+import { ConstraintServiceContext, useEventBus } from 'src/useEventBus'
 
 import { CODES } from '../common'
 import { RunQueryButton } from '../Shared/Buttons'
@@ -69,7 +69,7 @@ export const TemplateQuery = ({ classView, rootUrl, template, mineName }) => {
 		where: withNoDefaults,
 	}
 
-	const [state] = useMachineBus(
+	const [state, , service] = useMachine(
 		templateQueryMachine.withContext({
 			...templateQueryMachine.context,
 			rootUrl,
@@ -78,6 +78,8 @@ export const TemplateQuery = ({ classView, rootUrl, template, mineName }) => {
 			constraints: editableConstraints,
 		})
 	)
+
+	const [sendToBus] = useEventBus(service)
 
 	const {
 		isActiveQuery,

--- a/src/components/Templates/templateConstraintMachine.js
+++ b/src/components/Templates/templateConstraintMachine.js
@@ -7,8 +7,8 @@ import {
 	REMOVE_CONSTRAINT,
 	TEMPLATE_CONSTRAINT_UPDATED,
 } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
-import { assign, Machine, sendUpdate } from 'xstate'
+import { sendToBus } from 'src/useEventBus'
+import { assign, Machine } from 'xstate'
 
 import { logErrorToConsole } from '../../utils'
 
@@ -55,7 +55,7 @@ export const templateConstraintMachine = Machine(
 					src: 'fetchConstraintValues',
 					onDone: {
 						target: 'idle',
-						actions: ['setAvailableValues', 'sendUpdate'],
+						actions: 'setAvailableValues',
 					},
 					onError: {
 						target: 'noValuesForConstraint',
@@ -88,7 +88,6 @@ export const templateConstraintMachine = Machine(
 			removeValueFromConstraint,
 			setAvailableValues,
 			updateTemplateQuery,
-			sendUpdate,
 		},
 		guards: {
 			// @ts-ignore

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -5,7 +5,7 @@ import {
 	REMOVE_LIST_CONSTRAINT,
 	TEMPLATE_CONSTRAINT_UPDATED,
 } from 'src/eventConstants'
-import { sendToBus } from 'src/useMachineBus'
+import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
 
 import { listConstraintQuery } from '../common'

--- a/src/components/Widgets/CheckboxWidget.jsx
+++ b/src/components/Widgets/CheckboxWidget.jsx
@@ -1,7 +1,7 @@
 import { Checkbox, Label } from '@blueprintjs/core'
 import React from 'react'
 import { ADD_CONSTRAINT, REMOVE_CONSTRAINT } from 'src/eventConstants'
-import { useServiceContext } from 'src/useMachineBus'
+import { useServiceContext } from 'src/useEventBus'
 
 import { NoValuesProvided } from '../Shared/NoValuesProvided'
 

--- a/src/components/Widgets/SuggestWidget.jsx
+++ b/src/components/Widgets/SuggestWidget.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { FixedSizeList as List } from 'react-window'
 import { ADD_CONSTRAINT, REMOVE_CONSTRAINT } from 'src/eventConstants'
 import { generateId } from 'src/generateId'
-import { useServiceContext } from 'src/useMachineBus'
+import { useServiceContext } from 'src/useEventBus'
 import { pluralizeFilteredCount } from 'src/utils'
 
 import { NoValuesProvided } from '../Shared/NoValuesProvided'

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -18,6 +18,7 @@ export const SET_AVAILABLE_COLUMNS = 'global/table/set_columns'
  */
 export const DELETE_QUERY_CONSTRAINT = 'queryController/constraint/delete'
 export const ADD_QUERY_CONSTRAINT = 'queryController/constraint/add'
+export const RESET_QUERY_CONTROLLER = 'queryController/constraint/reset'
 
 /**
  * constraints


### PR DESCRIPTION
The overview queries could not be executed after switching to and back
from the template view. This occurred because the overview constraints
and the template view constraints were being spawned, and therefore not
initialized in the event bus as before. This PR also spawns the
query controller so that it can stay persistent like the other actors.

This PR also refactors the event bus to use hooks so the components
can explicitly register to the bus.

Closes: #142 