### PR TITLE
Show loaders while the mine configuration loads

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,14 +4,8 @@ import '@emotion/core'
 import { Card } from '@blueprintjs/core'
 import { useMachine } from '@xstate/react'
 import { enableMapSet } from 'immer'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useWindowSize } from 'react-use'
-import {
-	FETCH_INITIAL_SUMMARY,
-	FETCH_OVERVIEW_CONSTRAINTS,
-	FETCH_TEMPLATES,
-	RESET_QUERY_CONTROLLER,
-} from 'src/eventConstants'
 import { AppManagerServiceContext, useEventBus } from 'src/useEventBus'
 
 import logo from '../../images/logo.png'
@@ -26,19 +20,10 @@ enableMapSet()
 
 export const App = () => {
 	const [state, send, service] = useMachine(appManagerMachine)
-	const [sendToBus] = useEventBus(service)
+	useEventBus(service)
 	const { height } = useWindowSize()
 
-	const { classView, selectedMine, viewActors } = state.context
-
-	const rootUrl = selectedMine.rootUrl
-
-	useEffect(() => {
-		send({ type: FETCH_OVERVIEW_CONSTRAINTS })
-		send({ type: FETCH_TEMPLATES })
-		send({ type: RESET_QUERY_CONTROLLER })
-		sendToBus({ type: FETCH_INITIAL_SUMMARY, classView, rootUrl })
-	}, [classView, rootUrl, selectedMine, send, sendToBus])
+	const { viewActors } = state.context
 
 	return (
 		<div className="light-theme">

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -3,13 +3,14 @@ import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
 import React, { useEffect, useState } from 'react'
 import { CHANGE_MINE, SET_API_TOKEN } from 'src/eventConstants'
-import { useServiceContext } from 'src/useEventBus'
+import { useEventBus, useServiceContext } from 'src/useEventBus'
 
 import { NumberedSelectMenuItems } from '../Shared/Selects'
 
 export const MineSelector = () => {
 	const [state, send] = useServiceContext('appManager')
 	const [showPopup, setShowPopup] = useState(false)
+	const [sendToBus] = useEventBus()
 
 	const { selectedMine, intermines } = state.context
 	const [apiToken, setApiToken] = useState(selectedMine.apiToken)
@@ -23,7 +24,8 @@ export const MineSelector = () => {
 	}, [currentMine, selectedMine.rootUrl, selectedMine.apiToken])
 
 	const handleMineChange = ({ name }) => {
-		send({ type: CHANGE_MINE, newMine: name })
+		// @ts-ignore
+		sendToBus({ type: CHANGE_MINE, newMine: name })
 	}
 
 	const isAuthenticated = selectedMine.apiToken.length > 0

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchSummary } from 'src/apiRequests'
 import { pieChartCache } from 'src/caches'
-import { FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
+import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_UPDATED_SUMMARY } from 'src/eventConstants'
 import { assign, Machine } from 'xstate'
 
 const setSummaryResults = assign({
@@ -16,20 +16,26 @@ const setSummaryResults = assign({
 export const PieChartMachine = Machine(
 	{
 		id: 'PieChart',
-		initial: 'hasNoSummary',
+		initial: 'waitingOnMineToLoad',
 		context: {
 			allClassOrganisms: [],
 			classView: '',
 			rootUrl: '',
 		},
 		on: {
-			// Making it global ensure we update the table when the mine/class changes
-			[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
-			[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
+			[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
 		},
 		states: {
 			idle: {
 				always: [{ target: 'hasNoSummary', cond: 'hasNoSummary' }],
+				on: {
+					[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
+				},
+			},
+			waitingOnMineToLoad: {
+				on: {
+					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+				},
 			},
 			loading: {
 				invoke: {

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -41,14 +41,11 @@ export const SET_INITIAL_ORGANISMS = 'pieChart/fetch/initial'
  */
 export const CHANGE_MINE = 'appManager/mine/change'
 export const CHANGE_CLASS = 'appManager/class/change'
-export const CHANGE_CONSTRAINT_VIEW = 'appManager/view/change'
 export const TOGGLE_CATEGORY_VISIBILITY = 'appManager/category/visibility'
 export const TOGGLE_VIEW_IS_LOADING = 'appManager/view/isLoading'
 export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 export const SET_API_TOKEN = 'appManager/api/token'
-export const FETCH_TEMPLATES = 'appManager/fetch/templates'
-export const FETCH_OVERVIEW_CONSTRAINTS = 'appManager/fetch/overviewConstraints'
 
 /**
  * Table


### PR DESCRIPTION
When first loading the app, the data viz shows no results are available,
which leads to the belief there is an error. And when the mine changes,
the data viz does not update, making it seem that the UI has hung up.

This PR resolves both issues by showing loading skeleton screens at
first load, and whenever the mine changes.

Closes: #145 