### PR TITLE
Show default values for template constraints

### DIFF
--- a/src/caches.js
+++ b/src/caches.js
@@ -2,32 +2,40 @@ import localForage from 'localforage'
 
 export const appCache = localForage.createInstance({
 	name: 'app',
+	version: 1.0,
 })
 
 export const pieChartCache = localForage.createInstance({
 	name: 'pie chart',
+	version: 1.0,
 })
 
 export const barChartCache = localForage.createInstance({
 	name: 'bar chart',
+	version: 1.0,
 })
 
 export const tableCache = localForage.createInstance({
 	name: 'table',
+	version: 1.0,
 })
 
 export const constraintValuesCache = localForage.createInstance({
 	name: 'constraint values',
+	version: 1.0,
 })
 
 export const templatesCache = localForage.createInstance({
 	name: 'templates',
+	version: 1.0,
 })
 
 export const searchIndexCache = localForage.createInstance({
 	name: 'search indexes',
+	version: 1.0,
 })
 
 export const interminesConfigCache = localForage.createInstance({
 	name: 'intermines',
+	version: 1.0,
 })

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -78,7 +78,7 @@ const TemplatesList = ({ templateViewActor }) => {
 		categoryTagsForClass,
 	} = state.context
 
-	const showAll = categories[showAllLabel].isVisible ?? true
+	const showAll = categories[showAllLabel]?.isVisible ?? true
 	const isLoading = state.matches('loadTemplates')
 
 	const handleCategoryToggle = ({ isVisible, tagName }) => {

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -76,11 +76,15 @@ const spawnConstraintActors = assign({
 	constraintActors: (ctx) => {
 		return ctx.constraints.map((constraint) => {
 			const name = constraint.path.split('.').join(' > ')
+			const selectedValues = constraint.values ? constraint.values : [constraint.value]
+
 			const constraintActor = templateConstraintMachine.withContext({
 				...templateConstraintMachine.context,
 				rootUrl: ctx.rootUrl,
 				name,
 				constraint,
+				selectedValues,
+				defaultSelections: selectedValues,
 			})
 
 			return spawn(constraintActor, `${name}-Template constraint widget`)

--- a/src/components/Widgets/InputWidget.jsx
+++ b/src/components/Widgets/InputWidget.jsx
@@ -1,0 +1,34 @@
+import { InputGroup } from '@blueprintjs/core'
+import React from 'react'
+import { ADD_CONSTRAINT } from 'src/eventConstants'
+import { useServiceContext } from 'src/useEventBus'
+
+export const InputWidget = ({ operationLabel }) => {
+	const [state, send] = useServiceContext('constraints')
+
+	const { selectedValues } = state.context
+
+	return (
+		<div css={{ display: 'flex' }}>
+			<div
+				css={{
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					marginRight: 5,
+					border: '1px solid var(--grey3)',
+					borderRadius: 3,
+					width: 100,
+					height: 30,
+				}}
+			>
+				{operationLabel}
+			</div>
+			<InputGroup
+				fill={true}
+				value={selectedValues[0]}
+				onChange={(e) => send({ type: ADD_CONSTRAINT, constraint: e.target.value })}
+			/>
+		</div>
+	)
+}

--- a/src/components/Widgets/SelectWidget.jsx
+++ b/src/components/Widgets/SelectWidget.jsx
@@ -1,0 +1,59 @@
+import { Button, Classes, FormGroup, MenuItem } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+import { Select } from '@blueprintjs/select'
+import React, { useState } from 'react'
+import { operationsDict } from 'src/constraintOperations'
+import { ADD_CONSTRAINT } from 'src/eventConstants'
+import { generateId } from 'src/generateId'
+import { useServiceContext } from 'src/useEventBus'
+
+const renderItems = (item, { handleClick, modifiers }) => {
+	if (!modifiers.matchesPredicate) {
+		return null
+	}
+
+	return (
+		<MenuItem active={modifiers.active} key={item.value} onClick={handleClick} text={item.value} />
+	)
+}
+
+export const SelectWidget = () => {
+	const [uniqueId] = useState(() => `selectWidget-${generateId()}`)
+	const [state, send] = useServiceContext('constraints')
+	const { availableValues, constraint, selectedValues } = state.context
+
+	const handleItemSelect = ({ value }) => {
+		send({ type: ADD_CONSTRAINT, constraint: value })
+	}
+
+	return (
+		<FormGroup css={{ [`& .${Classes.FORM_CONTENT}`]: { display: 'flex' } }}>
+			<div
+				css={{
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					marginRight: 5,
+					border: '1px solid var(--grey3)',
+					borderRadius: 3,
+					minWidth: 28,
+					height: 30,
+				}}
+			>
+				{operationsDict[constraint.op]}
+			</div>
+			<Select
+				// @ts-ignore
+				id={uniqueId}
+				filterable={false}
+				items={availableValues}
+				itemRenderer={renderItems}
+				onItemSelect={handleItemSelect}
+				itemPredicate={(q, item) => item}
+				popoverProps={{ captureDismiss: true }}
+			>
+				<Button text={selectedValues[0]} rightIcon={IconNames.CARET_DOWN} />
+			</Select>
+		</FormGroup>
+	)
+}

--- a/src/components/Widgets/SuggestWidget.jsx
+++ b/src/components/Widgets/SuggestWidget.jsx
@@ -110,11 +110,11 @@ const renderMenu = (handleItemSelect, isLoading) => ({
 export const SuggestWidget = ({
 	nonIdealTitle = undefined,
 	nonIdealDescription = undefined,
-	label = '',
+	operationLabel = null,
 	searchIndex,
 	docField = '',
 }) => {
-	const [uniqueId] = useState(() => `selectPopup-${generateId()}`)
+	const [uniqueId] = useState(() => `suggestWidget-${generateId()}`)
 	const [state, send] = useServiceContext('constraints')
 	const { availableValues, selectedValues } = state.context
 
@@ -163,7 +163,7 @@ export const SuggestWidget = ({
 			{selectedValues.length > 0 && (
 				<div css={{ display: 'flex', alignItems: 'center' }}>
 					{state.context.op && <H6 css={{ margin: '0 10px 0 0' }}>{state.context.op}</H6>}
-					<div css={{ maxWidth: '50%' }}>
+					<div>
 						{selectedValues.map((val) => (
 							<Tag
 								key={val}
@@ -177,10 +177,30 @@ export const SuggestWidget = ({
 					</div>
 				</div>
 			)}
-			<FormGroup labelFor={uniqueId} label={label} css={{ paddingTop: 14 }}>
+			<FormGroup
+				labelFor={uniqueId}
+				inline={true}
+				css={{ paddingTop: 14, [`& .${Classes.FORM_CONTENT}`]: { display: 'flex', width: '100%' } }}
+			>
+				{operationLabel && (
+					<div
+						css={{
+							display: 'flex',
+							justifyContent: 'center',
+							alignItems: 'center',
+							marginRight: 5,
+							border: '1px solid var(--grey3)',
+							borderRadius: 3,
+							width: 100,
+							height: 30,
+						}}
+					>
+						{operationLabel}
+					</div>
+				)}
 				<Suggest
 					// @ts-ignore
-					id={`selectPopup-${uniqueId}`}
+					id={uniqueId}
 					items={availableValues}
 					inputValueRenderer={renderInputValue}
 					fill={true}

--- a/src/constraintOperations.js
+++ b/src/constraintOperations.js
@@ -1,0 +1,77 @@
+export const operationsDict = {
+	'=': '=',
+	'==': '==',
+	eq: '=',
+	eqq: '==',
+	'!=': '!=',
+	ne: '!=',
+	'>': '>',
+	gt: '>',
+	'>=': '>=',
+	ge: '>=',
+	'<': '<',
+	lt: '<',
+	'<=': '<=',
+	le: '<=',
+	contains: 'CONTAINS',
+	CONTAINS: 'CONTAINS',
+	'does not contain': 'DOES NOT CONTAIN',
+	'DOES NOT CONTAIN': 'DOES NOT CONTAIN',
+	like: 'LIKE',
+	LIKE: 'LIKE',
+	'not like': 'NOT LIKE',
+	'NOT LIKE': 'NOT LIKE',
+	lookup: 'LOOKUP',
+	'IS NULL': 'IS NULL',
+	'is null': 'IS NULL',
+	'IS NOT NULL': 'IS NOT NULL',
+	'is not null': 'IS NOT NULL',
+	'ONE OF': 'ONE OF',
+	'one of': 'ONE OF',
+	'NONE OF': 'NONE OF',
+	'none of': 'NONE OF',
+	in: 'IN',
+	'not in': 'NOT IN',
+	IN: 'IN',
+	'NOT IN': 'NOT IN',
+	WITHIN: 'WITHIN',
+	within: 'WITHIN',
+	OVERLAPS: 'OVERLAPS',
+	overlaps: 'OVERLAPS',
+	'DOES NOT OVERLAP': 'DOES NOT OVERLAP',
+	'does not overlap': 'DOES NOT OVERLAP',
+	OUTSIDE: 'OUTSIDE',
+	outside: 'OUTSIDE',
+	ISA: 'ISA',
+	isa: 'ISA',
+}
+
+export const isSingleSelection = Object.keys(operationsDict).filter((key) => {
+	const value = operationsDict[key]
+
+	switch (value) {
+		case '=':
+		case '==':
+		case 'eq':
+		case 'eqq':
+		case '!=':
+		case 'ne':
+			return true
+		default:
+			return false
+	}
+})
+
+export const isMultiSelection = Object.keys(operationsDict).filter((key) => {
+	const value = operationsDict[key]
+
+	switch (value) {
+		case 'ONE OF':
+		case 'NONE OF':
+			return true
+		default:
+			return false
+	}
+})
+
+export const fetchableConstraintOps = [...isSingleSelection, ...isMultiSelection]


### PR DESCRIPTION
This PR displays the default values for template constraints, along
with the operation used for it. If a constraint is completely removed,
the `Run Query` button will be disabled, so that the templates stay
properly formatted. There is also an option to reset all constraints to
the default values.

For now, constraints that have more than 1000 items are displayed as an
Input widget. This is for 2 reasons:

1. Select dropdowns are not virtualized, and rendering that many elements
will cause the UI to seriously lag.

2. Bluegenes currently does something similar. Although the actual cutoff
may not be the same as this app.

Closes: #147 