### PR TITLE
Allow running the default query when no constraints are selected

### DIFF
--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -63,7 +63,12 @@ export const BarChartMachine = Machine(
 					},
 				},
 			},
-			noGeneLengths: {},
+			noGeneLengths: {
+				on: {
+					[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
+					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+				},
+			},
 		},
 	},
 	{
@@ -93,6 +98,7 @@ export const BarChartMachine = Machine(
 					],
 				}
 
+				console.log('here')
 				const summaryConfig = { rootUrl, query, path: 'length' }
 				const configHash = hash(summaryConfig)
 				let summary

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -51,7 +51,12 @@ export const PieChartMachine = Machine(
 					},
 				},
 			},
-			hasNoSummary: {},
+			hasNoSummary: {
+				on: {
+					[FETCH_UPDATED_SUMMARY]: { target: 'loading' },
+					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
+				},
+			},
 		},
 	},
 	{

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -89,6 +89,11 @@ export const QueryController = ({ queryControllerActor }) => {
 	}
 
 	const runQuery = () => {
+		if (currentConstraints.length === 0) {
+			sendToBus({ type: FETCH_UPDATED_SUMMARY, classView, rootUrl })
+			return
+		}
+
 		let constraintLogic = ''
 
 		const constraints =
@@ -144,11 +149,7 @@ export const QueryController = ({ queryControllerActor }) => {
 					/>
 				</QueryServiceContext.Provider>
 			</PopupCard>
-			<RunQueryButton
-				intent={currentConstraints.length === 0 ? 'none' : 'success'}
-				isDisabled={currentConstraints.length === 0}
-				handleOnClick={runQuery}
-			/>
+			<RunQueryButton intent="success" handleOnClick={runQuery} />
 		</div>
 	)
 }

--- a/src/components/Table/tableMachine.js
+++ b/src/components/Table/tableMachine.js
@@ -129,7 +129,15 @@ export const TableChartMachine = Machine(
 					},
 				},
 			},
-			noTableSummary: {},
+			noTableSummary: {
+				on: {
+					[FETCH_INITIAL_SUMMARY]: {
+						target: 'fetchInitialRows',
+						actions: 'bustCachedPages',
+					},
+					[FETCH_UPDATED_SUMMARY]: { target: 'fetchInitialRows', actions: 'bustCachedPages' },
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
When in the overview constraint tab, we currently are not able to run
a default query if no queries are selected. This commit allows running a
blank, default query. This way after a query has been executed, and the
constraints removed, a user can run the default query again.

Closes: #149 