### PR TITLE
Fix: checkmark tick not showing in checkboxes

### DIFF
--- a/src/blueprintIcons.js
+++ b/src/blueprintIcons.js
@@ -23,4 +23,5 @@ exports.usedIcons = [
 	IconNames.REMOVE,
 	IconNames.DELETE,
 	IconNames.INFO_SIGN,
+	IconNames.SMALL_CROSS,
 ]

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,6 @@ import 'normalize.css'
 import './theme/main.css'
 
 import { FocusStyleManager } from '@blueprintjs/core'
-import { css, Global } from '@emotion/core'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
@@ -11,19 +10,7 @@ import * as serviceWorker from './serviceWorker'
 
 FocusStyleManager.onlyShowFocusOnTabs()
 
-ReactDOM.render(
-	<>
-		<Global
-			styles={css`
-				body {
-					overflow: hidden;
-				}
-			`}
-		/>
-		<App />
-	</>,
-	document.getElementById('root')
-)
+ReactDOM.render(<App />, document.getElementById('root'))
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -3,3 +3,11 @@
 
 @import '@blueprintjs/core/src/blueprint.scss';
 @import '@blueprintjs/select/src/blueprint-select.scss';
+
+.bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator:before {
+	background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='rgba(255,255,255,1)'/%3E%3C/svg%3E");
+}
+
+body {
+	overflow: hidden;
+}


### PR DESCRIPTION
Blueprintjs has a very particular sass setup, and it needs to be recreated
in order to fully work with their build. Since we are modifying the sass
variables, we are not able to replicate it, and therefore the inline
svgs are not being displayed.

This commit manually adds the checkmark inline ticks to the main sass
file. It was lifted from this comment in the Blueprintjs issues tracker
https://github.com/palantir/blueprint/issues/2821#issuecomment-414645690

Closes: #151 