### PR TITLE
Expire the caches that are older than 24 hours

### DIFF
--- a/src/caches.js
+++ b/src/caches.js
@@ -1,41 +1,66 @@
 import localForage from 'localforage'
 
-export const appCache = localForage.createInstance({
-	name: 'app',
-	version: 1.0,
-})
+// 24 hours
+const CACHE_EXPIRY_TIME = 1000 * 60 * 60 * 24
+const INTERVAL = 1000 * 60
+
+export const purgeExpiredCaches = (cache) => {
+	const interval = setInterval(async () => {
+		const now = Date.now()
+
+		try {
+			await cache.iterate(async (value, key) => {
+				if (now - value.date > CACHE_EXPIRY_TIME) {
+					await cache.removeItem(key)
+				}
+			})
+		} catch (e) {
+			console.error(`Error purging expired cache key. Deleting the database instead`)
+			await cache.clear()
+		}
+	}, INTERVAL)
+
+	return interval
+}
 
 export const pieChartCache = localForage.createInstance({
 	name: 'pie chart',
 	version: 1.0,
 })
+purgeExpiredCaches(pieChartCache)
 
 export const barChartCache = localForage.createInstance({
 	name: 'bar chart',
 	version: 1.0,
 })
+purgeExpiredCaches(barChartCache)
 
 export const tableCache = localForage.createInstance({
 	name: 'table',
 	version: 1.0,
 })
+purgeExpiredCaches(tableCache)
 
 export const constraintValuesCache = localForage.createInstance({
 	name: 'constraint values',
 	version: 1.0,
 })
+purgeExpiredCaches(constraintValuesCache)
 
 export const templatesCache = localForage.createInstance({
 	name: 'templates',
 	version: 1.0,
 })
+purgeExpiredCaches(templatesCache)
 
 export const searchIndexCache = localForage.createInstance({
 	name: 'search indexes',
 	version: 1.0,
 })
+purgeExpiredCaches(searchIndexCache)
 
 export const interminesConfigCache = localForage.createInstance({
 	name: 'intermines',
 	version: 1.0,
 })
+purgeExpiredCaches(interminesConfigCache)


### PR DESCRIPTION
Since the data in the intermines doesn't change often, we can cache
previous query results. But the data does change, so this commit will
expire the caches after 24 hours so fresh data can be fetched. The
validation check runs every minute.

Closes: #155 