### PR TITLE
Add option to export the table results to a file

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@xstate/react": "^0.8.1",
 		"axios": "^0.19.2",
 		"babel-plugin-emotion": "^10.0.33",
+		"file-saver": "^2.0.2",
 		"flexsearch": "^0.6.32",
 		"imjs": "^4.0.0",
 		"immer": "^7.0.5",

--- a/src/apiRequests.js
+++ b/src/apiRequests.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { saveAs } from 'file-saver'
 import imjs from 'imjs'
 
 import { formatConstraintPath } from './utils'
@@ -78,4 +79,14 @@ export const fetchLists = async (rootUrl) => {
 	const service = getService(rootUrl)
 
 	return await service.fetchLists()
+}
+
+export const exportTable = async ({ query, rootUrl, format, fileName }) => {
+	const service = getService(rootUrl)
+	const q = await service.query(query)
+
+	const file = await service.post('query/results', { format, query: q.toXML() })
+	const blob = new Blob([file])
+
+	saveAs(blob, `${fileName}.${format}`)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10958,6 +10958,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-saver@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "file-saver@npm:2.0.2"
+  checksum: 3b4e66bf4ec88740b4076792b74db91e534e27400babe43a5a0b533238551842e5e1bd108c350b3e2129de14be0d11759a3098ba0d4d19f7eaaf88976f6fd415
+  languageName: node
+  linkType: hard
+
 "file-system-cache@npm:^1.0.5":
   version: 1.0.5
   resolution: "file-system-cache@npm:1.0.5"
@@ -12864,6 +12871,7 @@ fsevents@^1.2.7:
     eslint-plugin-react: 7.x
     eslint-plugin-react-hooks: 2.x
     eslint-plugin-simple-import-sort: ^5.0.3
+    file-saver: ^2.0.2
     flexsearch: ^0.6.32
     husky: ">=4"
     imjs: ^4.0.0


### PR DESCRIPTION
This PR adds the ability to export the table results in tsv, and csv
formats. There are other formats handled by im-tables, but I couldn't
fully grasp how the calls were being made. Using the imjs methods would
crash the browser, probably because too much data was being requested.
This will require further discussion, so is being moved to a future story.

Closes: #157 