### PR TITLE
Generate code snippets for the current table results

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"babel-plugin-emotion": "^10.0.33",
 		"file-saver": "^2.0.2",
 		"flexsearch": "^0.6.32",
+		"highlight.js": "^10.1.2",
 		"imjs": "^4.0.0",
 		"immer": "^7.0.5",
 		"localforage": "^1.8.1",

--- a/src/apiRequests.js
+++ b/src/apiRequests.js
@@ -90,3 +90,23 @@ export const exportTable = async ({ query, rootUrl, format, fileName }) => {
 
 	saveAs(blob, `${fileName}.${format}`)
 }
+
+export const fetchCode1 = async ({ query, lang, rootUrl, fileName }) => {
+	const service = getService(rootUrl)
+	const q = await service.query(query)
+
+	return await q.fetchCode(lang)
+}
+
+export const fetchCode = async ({ query, lang, rootUrl, codeCache }) => {
+	if (!query || Object.keys(query).length === 0) {
+		return
+	}
+
+	if (!(lang in codeCache)) {
+		const service = getService(rootUrl)
+		const q = await service.query(query)
+
+		return await q.fetchCode(lang)
+	}
+}

--- a/src/components/Table/ExportTableButton.jsx
+++ b/src/components/Table/ExportTableButton.jsx
@@ -1,0 +1,78 @@
+import { Button, ControlGroup, Dialog, FormGroup, InputGroup, MenuItem } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+import { Select } from '@blueprintjs/select'
+import React, { useState } from 'react'
+import { exportTable } from 'src/apiRequests'
+
+/**
+ *
+ */
+export const ExportTableButton = ({ query, rootUrl }) => {
+	const [isOpen, setIsOpen] = useState(false)
+	const [format, setFormat] = useState('tsv')
+	const [fileName, setFileName] = useState('table data result')
+	const [, setErrorDownloading] = useState(false)
+
+	const handleOnClose = () => setIsOpen(false)
+
+	const handleExport = async () => {
+		try {
+			await exportTable({ query, rootUrl, format, fileName })
+		} catch (e) {
+			// Todo: display an error message
+			setErrorDownloading(true)
+			console.error(`Error downloading file: ${e}`)
+		}
+	}
+
+	return (
+		<>
+			<Button
+				intent="primary"
+				outlined={true}
+				icon={IconNames.ARCHIVE}
+				text="Export"
+				onClick={() => setIsOpen(true)}
+			/>
+			<Dialog
+				title="Export Table Data"
+				isOpen={isOpen}
+				canEscapeKeyClose={true}
+				onClose={handleOnClose}
+			>
+				<div css={{ padding: 40 }}>
+					<ControlGroup css={{ display: 'flex' }}>
+						<FormGroup label="Filename" labelFor="table-download-filename" labelInfo="(optional)">
+							<InputGroup
+								id="table-download-filename"
+								value={fileName}
+								fill={false}
+								css={{ width: 160 }}
+								onChange={(e) => setFileName(e.target.value)}
+							/>
+						</FormGroup>
+						<Select
+							filterable={false}
+							items={['tsv', 'csv']}
+							itemRenderer={(format, { handleClick }) => {
+								// @ts-ignore
+								return <MenuItem key={format} text={format} onClick={handleClick} />
+							}}
+							onItemSelect={setFormat}
+							css={{ alignSelf: 'center', marginTop: 8 }}
+						>
+							<Button intent="none" rightIcon={IconNames.CARET_DOWN} text={format} />
+						</Select>
+					</ControlGroup>
+					<Button
+						intent="primary"
+						icon={IconNames.ARCHIVE}
+						text="Download results"
+						onClick={handleExport}
+						css={{ marginTop: 10 }}
+					/>
+				</div>
+			</Dialog>
+		</>
+	)
+}

--- a/src/components/Table/GenerateCodeButton.jsx
+++ b/src/components/Table/GenerateCodeButton.jsx
@@ -1,0 +1,255 @@
+import 'highlight.js/styles/github.css'
+
+import {
+	Button,
+	ButtonGroup,
+	Code,
+	ControlGroup,
+	Dialog,
+	FormGroup,
+	InputGroup,
+	MenuItem,
+	Pre,
+} from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+import { Select } from '@blueprintjs/select'
+import { saveAs } from 'file-saver'
+import hljs from 'highlight.js/lib/core'
+import java from 'highlight.js/lib/languages/java'
+import javascript from 'highlight.js/lib/languages/javascript'
+import perl from 'highlight.js/lib/languages/perl'
+import python from 'highlight.js/lib/languages/python'
+import ruby from 'highlight.js/lib/languages/ruby'
+// html is aliased as xml
+import html from 'highlight.js/lib/languages/xml'
+import hash from 'object-hash'
+import React, { useEffect, useState } from 'react'
+import { usePrevious } from 'react-use'
+import { fetchCode } from 'src/apiRequests'
+
+hljs.registerLanguage('javascript', javascript)
+hljs.registerLanguage('html', html)
+hljs.registerLanguage('java', java)
+hljs.registerLanguage('perl', perl)
+hljs.registerLanguage('python', python)
+hljs.registerLanguage('ruby', ruby)
+
+/**
+ *
+ */
+const codeNameToExtension = (lang) => {
+	switch (lang) {
+		case 'Python':
+			return 'py'
+		case 'Javascript':
+			return 'js'
+		case 'Perl':
+			return 'pl'
+		case 'Ruby':
+			return 'rb'
+		case 'Java':
+			return 'java'
+		default:
+			return 'js'
+	}
+}
+
+/**
+ *
+ */
+const CodeButtonSelect = ({
+	setLang,
+	intent,
+	text = '',
+	icon = null,
+	rightIcon = null,
+	outlined = false,
+	wrapperStyles = {},
+	buttonStyles = {},
+}) => {
+	return (
+		<Select
+			filterable={false}
+			items={['Javascript', 'Perl', 'Python', 'Ruby', 'Java']}
+			itemRenderer={(lang, { handleClick }) => {
+				// @ts-ignore
+				return <MenuItem key={lang} text={lang} onClick={handleClick} />
+			}}
+			onItemSelect={setLang}
+			css={wrapperStyles}
+		>
+			<Button
+				intent={intent}
+				icon={icon}
+				rightIcon={rightIcon}
+				text={text}
+				outlined={outlined}
+				css={buttonStyles}
+				alignText="left"
+			/>
+		</Select>
+	)
+}
+
+/**
+ *
+ */
+const FileNameInput = ({ fileName, setFileName, setLang, lang }) => {
+	return (
+		<ControlGroup css={{ display: 'flex' }}>
+			<FormGroup label="Filename" labelFor="generate-code" labelInfo="(optional)">
+				<InputGroup
+					id="generate-code"
+					value={fileName}
+					fill={false}
+					css={{ width: 160 }}
+					onChange={(e) => setFileName(e.target.value)}
+				/>
+			</FormGroup>
+			<CodeButtonSelect
+				setLang={setLang}
+				intent="none"
+				rightIcon={IconNames.CARET_DOWN}
+				text={lang}
+				buttonStyles={{ width: 112 }}
+				wrapperStyles={{ alignSelf: 'center', marginTop: 8 }}
+			/>
+		</ControlGroup>
+	)
+}
+
+/**
+ *
+ */
+const GenerateCodeDialog = ({ lang, handleDialogClose, isOpen, query, rootUrl, setLang }) => {
+	const prevLang = usePrevious(lang)
+	const [code, setCode] = useState({})
+	const [fileName, setFileName] = useState('query')
+	const [, setErrorDownloading] = useState(false)
+	const [lastQuery, setLastQuery] = useState('')
+
+	const fetchCodePreview = async () => {
+		const nextQuery = hash(query)
+		let codeCache = { ...code }
+
+		if (nextQuery !== lastQuery) {
+			codeCache = {}
+			setLastQuery(nextQuery)
+		}
+
+		try {
+			const file = await fetchCode({
+				query,
+				rootUrl,
+				codeCache,
+				lang: codeNameToExtension(lang),
+			})
+			setCode({
+				...codeCache,
+				[lang]: {
+					highlighted: hljs.highlightAuto(file).value,
+					plain: file,
+				},
+			})
+		} catch (e) {
+			// Todo: show error message
+			setErrorDownloading(true)
+			console.error(`Error fetching code: ${e}`)
+		}
+	}
+
+	useEffect(() => {
+		if (isOpen && prevLang !== lang) {
+			fetchCodePreview()
+		}
+	})
+	const handleFileSave = () => {
+		const blob = new Blob([code[lang].plain])
+		saveAs(blob, `${fileName}.${codeNameToExtension(lang)}`)
+	}
+
+	const renderCode = code[lang] || code[prevLang]
+	return (
+		<Dialog
+			title="Generate code snippet"
+			isOpen={isOpen}
+			canEscapeKeyClose={true}
+			onClose={handleDialogClose}
+			onOpening={fetchCodePreview}
+			css={{ width: 'auto' }}
+		>
+			<div css={{ padding: 20, display: 'flex', maxHeight: '500px', width: '50vw' }}>
+				<div css={{ marginTop: 20, marginRight: 20 }}>
+					<FileNameInput
+						fileName={fileName}
+						setFileName={setFileName}
+						setLang={setLang}
+						lang={lang}
+					/>
+					<Button
+						intent="primary"
+						icon={IconNames.ARCHIVE}
+						text="Download code"
+						onClick={handleFileSave}
+						css={{ marginTop: 10 }}
+					/>
+				</div>
+				<Pre
+					css={{
+						overflow: 'scroll',
+						minWidth: code[lang] ? 'auto' : 500,
+						minHeight: code[lang] ? 'auto' : 400,
+					}}
+				>
+					{renderCode ? (
+						<Code
+							dangerouslySetInnerHTML={{
+								__html: code[lang]?.highlighted ?? code[prevLang]?.highlighted,
+							}}
+						/>
+					) : (
+						<div>Fetching code. Please be patient...</div>
+					)}
+				</Pre>
+			</div>
+		</Dialog>
+	)
+}
+
+/**
+ *
+ */
+export const GenerateCodeButton = ({ query, rootUrl }) => {
+	const [isOpen, setIsOpen] = useState(false)
+	const [lang, setLang] = useState('Javascript')
+
+	const handleDialogClose = () => setIsOpen(false)
+
+	return (
+		<ButtonGroup css={{ margin: '0px 16px' }}>
+			<Button
+				intent="primary"
+				outlined={true}
+				icon={IconNames.CODE}
+				text={lang}
+				alignText="left"
+				onClick={() => setIsOpen(true)}
+				css={{ width: 112 }}
+			/>
+			<GenerateCodeDialog
+				lang={lang}
+				handleDialogClose={handleDialogClose}
+				isOpen={isOpen}
+				query={query}
+				rootUrl={rootUrl}
+				setLang={setLang}
+			/>
+			<CodeButtonSelect
+				setLang={setLang}
+				intent="primary"
+				icon={IconNames.CARET_DOWN}
+				outlined={true}
+			/>
+		</ButtonGroup>
+	)
+}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -1,153 +1,28 @@
 import {
 	Button,
-	ButtonGroup,
 	Classes,
 	ControlGroup,
-	Dialog,
-	FormGroup,
 	HTMLTable,
 	Icon,
 	InputGroup,
-	MenuItem,
 	Position,
 	Tooltip,
 } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
-import { Select } from '@blueprintjs/select'
 import { useMachine } from '@xstate/react'
 import React, { useEffect, useState } from 'react'
 import { useDebounce } from 'react-use'
 // use direct import because babel is not properly changing it in webpack
 import { useFirstMountState } from 'react-use/lib/useFirstMountState'
-import { exportTable } from 'src/apiRequests'
 import { CHANGE_PAGE } from 'src/eventConstants'
 import { TableServiceContext, useEventBus, useServiceContext } from 'src/useEventBus'
 import { tableLoadingData } from 'src/utils/loadingData/tableResults'
 import { humanize, titleize } from 'underscore.string'
 
 import { NonIdealStateWarning } from '../Shared/NonIdealStates'
+import { ExportTableButton } from './ExportTableButton'
+import { GenerateCodeButton } from './GenerateCodeButton'
 import { TableChartMachine } from './tableMachine'
-
-/**
- *
- */
-const ExportTableButton = ({ query, rootUrl }) => {
-	const [isOpen, setIsOpen] = useState(false)
-	const [format, setFormat] = useState('tsv')
-	const [fileName, setFileName] = useState('table data result')
-	const [, setErrorDownloading] = useState(false)
-
-	const handleOnClose = () => setIsOpen(false)
-
-	const handleExport = async () => {
-		try {
-			await exportTable({ query, rootUrl, format, fileName })
-		} catch (e) {
-			// Todo: display an error message
-			setErrorDownloading(true)
-			console.error(`Error downloading file: ${e}`)
-		}
-	}
-
-	return (
-		<>
-			<Button
-				intent="primary"
-				outlined={true}
-				icon={IconNames.ARCHIVE}
-				text="Export"
-				onClick={() => setIsOpen(true)}
-			/>
-			<Dialog
-				title="Export Table Data"
-				isOpen={isOpen}
-				canEscapeKeyClose={true}
-				onClose={handleOnClose}
-			>
-				<div css={{ padding: 40 }}>
-					<ControlGroup css={{ display: 'flex' }}>
-						<FormGroup label="Filename" labelFor="table-download-filename" labelInfo="(optional)">
-							<InputGroup
-								id="table-download-filename"
-								value={fileName}
-								fill={false}
-								css={{ width: 160 }}
-								onChange={(e) => setFileName(e.target.value)}
-							/>
-						</FormGroup>
-						<Select
-							filterable={false}
-							items={['tsv', 'csv']}
-							itemRenderer={(format, { handleClick }) => {
-								// @ts-ignore
-								return <MenuItem key={format} text={format} onClick={handleClick} />
-							}}
-							onItemSelect={setFormat}
-							css={{ alignSelf: 'center', marginTop: 8 }}
-						>
-							<Button intent="none" rightIcon={IconNames.CARET_DOWN} text={format} />
-						</Select>
-					</ControlGroup>
-					<Button
-						intent="primary"
-						icon={IconNames.ARCHIVE}
-						text="Download results"
-						onClick={handleExport}
-						css={{ marginTop: 10 }}
-					/>
-				</div>
-			</Dialog>
-		</>
-	)
-}
-
-/**
- *
- */
-const TableActionButtons = ({ query, rootUrl }) => {
-	const [selectedLanguage, setLanguage] = useState('Python')
-
-	return (
-		<div
-			css={{
-				display: 'flex',
-				justifyContent: 'flex-end',
-				marginBottom: '40px',
-			}}
-		>
-			{/* 
-			Save as list button 
-			*/}
-			<Button outlined={true} intent="primary" icon={IconNames.CLOUD_UPLOAD} text="Save As List" />
-			{/* 
-			Code snippet button
-			*/}
-			<ButtonGroup css={{ margin: '0px 16px' }}>
-				<Button
-					outlined={true}
-					intent="primary"
-					icon={IconNames.CODE}
-					text={`Generate ${selectedLanguage} code`}
-				/>
-				<Select
-					filterable={false}
-					items={['Python', 'Perl', 'Java', 'Ruby', 'Javascript', 'XML']}
-					itemRenderer={(lang, { handleClick }) => {
-						// @ts-ignore
-						return <MenuItem key={lang} text={lang} onClick={handleClick} />
-					}}
-					onItemSelect={setLanguage}
-				>
-					<Button outlined={true} intent="primary" icon={IconNames.CARET_DOWN} />
-				</Select>
-			</ButtonGroup>
-			{/* 
-			Export button 
-			*/}
-			<ExportTableButton query={query} rootUrl={rootUrl} />
-		</div>
-	)
-}
 
 /**
  *
@@ -325,7 +200,22 @@ export const Table = React.memo(function Table() {
 
 	return (
 		<TableServiceContext.Provider value={{ state, send }}>
-			<TableActionButtons query={lastQuery} rootUrl={rootUrl} />
+			<div
+				css={{
+					display: 'flex',
+					justifyContent: 'flex-end',
+					marginBottom: '40px',
+				}}
+			>
+				<Button
+					outlined={true}
+					intent="primary"
+					icon={IconNames.CLOUD_UPLOAD}
+					text="Save As List"
+				/>
+				<GenerateCodeButton query={lastQuery} rootUrl={rootUrl} />
+				<ExportTableButton query={lastQuery} rootUrl={rootUrl} />
+			</div>
 			<div css={{ display: 'flex', justifyContent: 'space-between', marginBottom: 20 }}>
 				<span
 					// @ts-ignore

--- a/yarn.lock
+++ b/yarn.lock
@@ -12182,6 +12182,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"highlight.js@npm:^10.1.2":
+  version: 10.1.2
+  resolution: "highlight.js@npm:10.1.2"
+  checksum: 12ad98d6f2b89ff7f46e2f9404bb3f3783c81cc5a98362e89e7f56d9d0315952149561e5f1661073e0bf8528412ce9262a331f27da4e263d122d34daa5473d08
+  languageName: node
+  linkType: hard
+
 "highlight.js@npm:~9.13.0":
   version: 9.13.1
   resolution: "highlight.js@npm:9.13.1"
@@ -12873,6 +12880,7 @@ fsevents@^1.2.7:
     eslint-plugin-simple-import-sort: ^5.0.3
     file-saver: ^2.0.2
     flexsearch: ^0.6.32
+    highlight.js: ^10.1.2
     husky: ">=4"
     imjs: ^4.0.0
     immer: ^7.0.5


### PR DESCRIPTION
This PR adds the feature for generating code snippets for the current
table results and query. Users will be able to set a file name if they
wish. Any fetched code will be cached locally, and will be busted if the
query changes. A text notification is displayed in the code section if
the code has yet to be loaded.

Closes: #159 