### PR TITLE
Fix: ensure templates change when the mine changes

### DIFF
--- a/src/components/App/appManagerMachine.js
+++ b/src/components/App/appManagerMachine.js
@@ -180,6 +180,9 @@ const spawnQueryControllerMachine = assign({
 	},
 })
 
+/**
+ *
+ */
 const fetchInitialSummaryForMine = (ctx) => {
 	sendToBus({
 		type: FETCH_SUMMARY,
@@ -187,6 +190,25 @@ const fetchInitialSummaryForMine = (ctx) => {
 		rootUrl: ctx.selectedMine.rootUrl,
 	})
 }
+
+/**
+ *
+ */
+const stopAllActors = assign({
+	viewActors: (ctx) => {
+		const { templateView, overview, queryController } = ctx.viewActors
+
+		templateView && templateView.stop()
+		overview && overview.stop()
+		queryController && queryController.stop()
+
+		return {
+			templateView: null,
+			overview: null,
+			queryController: null,
+		}
+	},
+})
 
 /**
  *
@@ -292,7 +314,7 @@ export const appManagerMachine = Machine(
 		on: {
 			[CHANGE_MINE]: {
 				target: 'loading',
-				actions: ['changeMine', 'getApiTokenFromStorage'],
+				actions: ['changeMine', 'stopAllActors', 'getApiTokenFromStorage'],
 			},
 			[CHANGE_CLASS]: {
 				actions: [
@@ -345,6 +367,7 @@ export const appManagerMachine = Machine(
 			spawnQueryControllerMachine,
 			setAppView,
 			fetchInitialSummaryForMine,
+			stopAllActors,
 		},
 		services: {
 			fetchMineConfiguration,

--- a/src/components/App/templateViewMachine.js
+++ b/src/components/App/templateViewMachine.js
@@ -122,7 +122,8 @@ const filterTemplatesForClassView = assign((ctx) => {
 		}
 	})
 
-	ctx.templatesForClassView = templatesForClassView
+	ctx.templatesForClassView = templatesForClassView.sort((a, b) => a.rank - b.rank)
+
 	ctx.categories[ctx.showAllLabel].count = templatesForClassView.length
 })
 
@@ -184,7 +185,7 @@ export const templateViewMachine = Machine(
 			templatesForClassView: [],
 			templatesForSelectedCategories: [],
 			categories: Object.create(null),
-			categoryTagsForClass: Object.create(null),
+			categoryTagsForClass: [],
 			classView: '',
 			showAllLabel: '',
 			rootUrl: '',

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -57,12 +57,6 @@ const ConstraintWidget = ({ templateConstraintActor, mineName }) => {
 		ConstraintWidget = SuggestWidget
 	}
 
-	// Todo: This path return over 77,000 values. For now we display it as an input to match blue genes.
-	// After virtualizing the Select widget, we can display the actual values, and allow searching for values.
-	if (availableValues.length > 1000) {
-		ConstraintWidget = InputWidget
-	}
-
 	return (
 		<ConstraintServiceContext.Provider value={{ state, send }}>
 			<div css={{ margin: '20px 0' }}>
@@ -82,6 +76,11 @@ const ConstraintWidget = ({ templateConstraintActor, mineName }) => {
 }
 
 export const TemplateQuery = ({ classView, template, rootUrl, mineName }) => {
+	// Some tempalates do not have a `where` constraints array
+	if (!template.where) {
+		template.where = []
+	}
+
 	const editableConstraints = template.where.filter((con) => con.editable)
 
 	const [state, , service] = useMachine(

--- a/src/components/Templates/templateConstraintMachine.js
+++ b/src/components/Templates/templateConstraintMachine.js
@@ -147,6 +147,13 @@ export const templateConstraintMachine = Machine(
 				} else {
 					values = await fetchPathValues(valuesConfig)
 
+					// Todo: Some paths return huge lists, some over 300k values. Setting it to an empty array
+					// will default to an input widget After virtualizing the Select widget, we can display the
+					// actual values, and allow searching for values.
+					if (values.length > 1000) {
+						values = []
+					}
+
 					await constraintValuesCache.setItem(configHash, {
 						...valuesConfig,
 						values,

--- a/src/components/Widgets/SelectWidget.jsx
+++ b/src/components/Widgets/SelectWidget.jsx
@@ -51,6 +51,7 @@ export const SelectWidget = () => {
 				onItemSelect={handleItemSelect}
 				itemPredicate={(q, item) => item}
 				popoverProps={{ captureDismiss: true }}
+				noResults="No items available"
 			>
 				<Button text={selectedValues[0]} rightIcon={IconNames.CARET_DOWN} />
 			</Select>


### PR DESCRIPTION
This PR fixes an issue where the templates were not refreshing when
the mine changed. This occurred because the template actors were not
stopped and reset before the component remounted, leading to stale data
access.

In addition, this PR persistently displays the category accordion,
sorts the templates by rank, and handles templates that have no
constraints set in the `where` array.

Closes: #165