### PR TITLE
Rehydrate the last query for each view

### DIFF
--- a/src/components/App/appManagerMachine.js
+++ b/src/components/App/appManagerMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchClasses, fetchInstances, fetchLists, INTERMINE_REGISTRY } from 'src/apiRequests'
 import { interminesConfigCache } from 'src/caches'
-import { CHANGE_CLASS, CHANGE_MINE, FETCH_SUMMARY, SET_API_TOKEN } from 'src/eventConstants'
+import { CHANGE_CLASS, CHANGE_MINE, FETCH_INITIAL_SUMMARY, SET_API_TOKEN } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
 
@@ -185,7 +185,7 @@ const spawnQueryControllerMachine = assign({
  */
 const fetchInitialSummaryForMine = (ctx) => {
 	sendToBus({
-		type: FETCH_SUMMARY,
+		type: FETCH_INITIAL_SUMMARY,
 		classView: ctx.classView,
 		rootUrl: ctx.selectedMine.rootUrl,
 	})

--- a/src/components/App/overviewMachine.js
+++ b/src/components/App/overviewMachine.js
@@ -1,3 +1,10 @@
+import {
+	CHANGE_CLASS,
+	FETCH_INITIAL_SUMMARY,
+	FETCH_OVERVIEW_SUMMARY,
+	FETCH_SUMMARY,
+} from 'src/eventConstants'
+import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
 
 import { overviewConstraintMachine } from '../Overview/overviewConstraintMachine'
@@ -81,6 +88,36 @@ const spawnConstraintActors = assign({
 	},
 })
 
+/**
+ *
+ */
+const assignLastOverviewQuery = assign({
+	// @ts-ignore
+	lastOverviewQuery: (_ctx, { query }) => {
+		console.log('asd')
+		return query
+	},
+})
+
+/**
+ *
+ */
+const resetLastOverviewQuery = assign({
+	lastOverviewQuery: () => {
+		return {}
+	},
+})
+
+/**
+ *
+ */
+const fetchOverviewSummary = (_ctx, { query, rootUrl, classView }) => {
+	sendToBus({ type: FETCH_SUMMARY, query, rootUrl, classView })
+}
+
+/**
+ *
+ */
 export const overviewMachine = Machine(
 	{
 		id: 'overview',
@@ -90,16 +127,28 @@ export const overviewMachine = Machine(
 			constraintActors: [],
 			classView: '',
 			rootUrl: '',
+			lastOverviewQuery: {},
 		},
 		states: {
 			idle: {
 				entry: 'spawnConstraintActors',
+				on: {
+					[FETCH_INITIAL_SUMMARY]: { actions: 'assignLastOverviewQuery' },
+					[FETCH_OVERVIEW_SUMMARY]: {
+						actions: ['assignLastOverviewQuery', 'fetchOverviewSummary'],
+					},
+					[CHANGE_CLASS]: { actions: 'resetLastOverviewQuery' },
+				},
 			},
 		},
 	},
 	{
 		actions: {
 			spawnConstraintActors,
+			assignLastOverviewQuery,
+			resetLastOverviewQuery,
+			// @ts-ignore
+			fetchOverviewSummary,
 		},
 	}
 )

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchSummary } from 'src/apiRequests'
 import { barChartCache } from 'src/caches'
-import { CHANGE_MINE, FETCH_SUMMARY } from 'src/eventConstants'
+import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
 import { assign, Machine } from 'xstate'
 
 import { logErrorToConsole } from '../../utils'
@@ -46,7 +46,7 @@ export const BarChartMachine = Machine(
 			},
 			waitingOnMineToLoad: {
 				on: {
-					[FETCH_SUMMARY]: { target: 'loading' },
+					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
 				},
 			},
 			loading: {

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchSummary } from 'src/apiRequests'
 import { pieChartCache } from 'src/caches'
-import { CHANGE_MINE, FETCH_SUMMARY } from 'src/eventConstants'
+import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
 import { assign, Machine } from 'xstate'
 
 const setSummaryResults = assign({
@@ -34,7 +34,7 @@ export const PieChartMachine = Machine(
 			},
 			waitingOnMineToLoad: {
 				on: {
-					[FETCH_SUMMARY]: { target: 'loading' },
+					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
 				},
 			},
 			loading: {

--- a/src/components/QueryController/QueryController.jsx
+++ b/src/components/QueryController/QueryController.jsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons'
 import { useService } from '@xstate/react'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY, FETCH_SUMMARY } from 'src/eventConstants'
+import { DELETE_OVERVIEW_CONSTRAINT_FROM_QUERY, FETCH_OVERVIEW_SUMMARY } from 'src/eventConstants'
 import { QueryServiceContext, useEventBus } from 'src/useEventBus'
 
 import { CODES } from '../common'
@@ -111,7 +111,7 @@ export const QueryController = ({ queryControllerActor }) => {
 			where: codedConstraints,
 		}
 
-		sendToBus({ type: FETCH_SUMMARY, query, classView, rootUrl })
+		sendToBus({ type: FETCH_OVERVIEW_SUMMARY, query, classView, rootUrl })
 	}
 
 	const handleDeleteConstraint = (path) => {

--- a/src/components/Table/tableMachine.js
+++ b/src/components/Table/tableMachine.js
@@ -1,7 +1,13 @@
 import hash from 'object-hash'
 import { fetchTable } from 'src/apiRequests'
 import { tableCache } from 'src/caches'
-import { CHANGE_MINE, CHANGE_PAGE, FETCH_SUMMARY, SET_AVAILABLE_COLUMNS } from 'src/eventConstants'
+import {
+	CHANGE_MINE,
+	CHANGE_PAGE,
+	FETCH_INITIAL_SUMMARY,
+	FETCH_SUMMARY,
+	SET_AVAILABLE_COLUMNS,
+} from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
 import { assign, Machine } from 'xstate'
 
@@ -80,7 +86,7 @@ export const TableChartMachine = Machine(
 		states: {
 			waitingOnMineToLoad: {
 				on: {
-					[FETCH_SUMMARY]: {
+					[FETCH_INITIAL_SUMMARY]: {
 						target: 'fetchInitialRows',
 						actions: 'bustCachedPages',
 					},

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -5,8 +5,8 @@ import React, { useEffect, useRef } from 'react'
 import { buildSearchIndex } from 'src/buildSearchIndex'
 import { isMultiSelection, isSingleSelection } from 'src/constraintOperations'
 import {
-	FETCH_SUMMARY,
 	FETCH_TEMPLATE_CONSTRAINT_ITEMS,
+	FETCH_TEMPLATE_SUMMARY,
 	RESET_OVERVIEW_CONSTRAINT,
 } from 'src/eventConstants'
 import { ConstraintServiceContext, useEventBus } from 'src/useEventBus'
@@ -165,7 +165,7 @@ export const TemplateQuery = ({ classView, template, rootUrl, mineName }) => {
 							query,
 							classView,
 							rootUrl,
-							type: FETCH_SUMMARY,
+							type: FETCH_TEMPLATE_SUMMARY,
 						})
 					}}
 				/>

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -37,7 +37,7 @@ const setQueries = assign({
  */
 const setActiveQuery = assign({
 	// @ts-ignore
-	isActiveQuery: (ctx, { query }) => query.name === ctx.template.name,
+	isActiveQuery: (ctx, { query }) => query?.name === ctx.template.name,
 })
 
 const addListConstraint = assign({

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -21,7 +21,10 @@ export const TEMPLATE_CONSTRAINT_UPDATED = 'constraint/template/updated'
  * Fetch
  */
 export const FETCH_TEMPLATE_CONSTRAINT_ITEMS = 'fetch/template/init'
-export const FETCH_SUMMARY = 'fetch/initial_summary'
+export const FETCH_SUMMARY = 'fetch/summary'
+export const FETCH_INITIAL_SUMMARY = 'fetch/initial_summary'
+export const FETCH_TEMPLATE_SUMMARY = 'fetch/templateSummary'
+export const FETCH_OVERVIEW_SUMMARY = 'fetch/overviewSummary'
 
 /**
  * AppManager


### PR DESCRIPTION
This PR saves the last executed query for each view. This way when
switching between constraint views, the previous query view will be rehydrated.

Closes: #167 