### PR TITLE
Add a global reset button for the view

### DIFF
--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -1,7 +1,8 @@
-import { Navbar } from '@blueprintjs/core'
+import { Button, Navbar } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
-import { CHANGE_CLASS } from 'src/eventConstants'
-import { useServiceContext } from 'src/useEventBus'
+import { CHANGE_CLASS, RESET_VIEW } from 'src/eventConstants'
+import { useEventBus, useServiceContext } from 'src/useEventBus'
 
 import { ClassSelector } from './ClassSelector'
 import { ListSelector } from './ListSelector'
@@ -13,6 +14,7 @@ import { MineSelector } from './MineSelector'
 export const NavigationBar = () => {
 	const [state, send] = useServiceContext('appManager')
 	const { classView, modelClasses, listsForCurrentClass, selectedMine } = state.context
+	const [sendToBus] = useEventBus()
 
 	const handleClassSelect = ({ name }) => {
 		send({ type: CHANGE_CLASS, newClass: name })
@@ -32,6 +34,15 @@ export const NavigationBar = () => {
 					listsForCurrentClass={listsForCurrentClass}
 					mineName={selectedMine.name}
 					classView={classView}
+				/>
+				<Button
+					text="Reset all"
+					intent="danger"
+					icon={IconNames.ERROR}
+					css={{ marginLeft: 'auto' }}
+					onClick={() => {
+						sendToBus({ type: RESET_VIEW })
+					}}
 				/>
 			</Navbar.Group>
 		</Navbar>

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -86,8 +86,10 @@ export const TemplateQuery = ({ classView, template, rootUrl, mineName }) => {
 	const [state, , service] = useMachine(
 		templateQueryMachine.withContext({
 			...templateQueryMachine.context,
+			classView,
 			rootUrl,
 			template,
+			baseTemplate: template,
 			isActiveQuery: false,
 			constraints: editableConstraints,
 		})

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -2,7 +2,9 @@ import {
 	ADD_LIST_CONSTRAINT,
 	ADD_TEMPLATE_CONSTRAINT,
 	FETCH_SUMMARY,
+	FETCH_TEMPLATE_SUMMARY,
 	REMOVE_LIST_CONSTRAINT,
+	RESET_VIEW,
 	TEMPLATE_CONSTRAINT_UPDATED,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
@@ -95,15 +97,38 @@ const spawnConstraintActors = assign({
 /**
  *
  */
+const resetTemplate = assign((ctx) => {
+	return {
+		template: ctx.baseTemplate,
+		isActiveQuery: false,
+	}
+})
+
+/**
+ *
+ */
+const resetTemplateSummary = ({ classView, rootUrl }) => {
+	sendToBus({
+		classView,
+		rootUrl,
+		type: FETCH_TEMPLATE_SUMMARY,
+	})
+}
+
+/**
+ *
+ */
 export const templateQueryMachine = Machine(
 	{
 		id: 'Template Query',
 		initial: 'idle',
 		context: {
-			template: null,
+			template: {},
+			baseTemplate: {},
 			isActiveQuery: false,
 			listConstraint: listConstraintQuery,
 			rootUrl: '',
+			classView: '',
 			constraints: [],
 			constraintActors: [],
 		},
@@ -115,6 +140,9 @@ export const templateQueryMachine = Machine(
 					[FETCH_SUMMARY]: { actions: 'setActiveQuery' },
 					[ADD_LIST_CONSTRAINT]: { actions: 'addListConstraint' },
 					[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
+					[RESET_VIEW]: {
+						actions: ['resetTemplate', 'spawnConstraintActors', 'resetTemplateSummary'],
+					},
 				},
 			},
 		},
@@ -126,6 +154,8 @@ export const templateQueryMachine = Machine(
 			addListConstraint,
 			removeListConstraint,
 			spawnConstraintActors,
+			resetTemplateSummary,
+			resetTemplate,
 		},
 		guards: {
 			// @ts-ignore

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -35,6 +35,7 @@ export const TOGGLE_CATEGORY_VISIBILITY = 'appManager/category/visibility'
 export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 export const SET_API_TOKEN = 'appManager/api/token'
+export const RESET_VIEW = 'appManager/reset/overview'
 
 /**
  * Table


### PR DESCRIPTION
This PR adds a global reset button to reset the visible view tab. It
will also reset the data viz to the initial query.

Closes: #169 