### PR TITLE
Reset the template view and overview separately

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -23,7 +23,7 @@ export const App = () => {
 	useEventBus(service)
 	const { height } = useWindowSize()
 
-	const { viewActors } = state.context
+	const { viewActors, appView } = state.context
 
 	return (
 		<div className="light-theme">
@@ -50,6 +50,7 @@ export const App = () => {
 					templateViewActor={viewActors.templateView}
 					overviewActor={viewActors.overview}
 					queryControllerActor={viewActors.queryController}
+					appView={appView}
 				/>
 				<section
 					id="data-viz"

--- a/src/components/App/appManagerMachine.js
+++ b/src/components/App/appManagerMachine.js
@@ -1,7 +1,13 @@
 import hash from 'object-hash'
 import { fetchClasses, fetchInstances, fetchLists, INTERMINE_REGISTRY } from 'src/apiRequests'
 import { interminesConfigCache } from 'src/caches'
-import { CHANGE_CLASS, CHANGE_MINE, FETCH_INITIAL_SUMMARY, SET_API_TOKEN } from 'src/eventConstants'
+import {
+	CHANGE_CLASS,
+	CHANGE_MINE,
+	FETCH_INITIAL_SUMMARY,
+	SET_API_TOKEN,
+	TOGGLE_VIEW,
+} from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
 
@@ -218,6 +224,14 @@ const logErrorToConsole = (ctx, event) => {
 }
 
 /**
+ *
+ */
+const assignAppView = assign({
+	// @ts-ignore
+	appView: (_, { newTabId }) => newTabId,
+})
+
+/**
  * Services
  */
 const fetchMineConfiguration = async (ctx) => {
@@ -292,6 +306,7 @@ export const appManagerMachine = Machine(
 				overview: null,
 				queryController: null,
 			},
+			appView: 'defaultView',
 			classView: 'Gene',
 			intermines: [],
 			modelClasses: [],
@@ -312,6 +327,7 @@ export const appManagerMachine = Machine(
 			},
 		},
 		on: {
+			[TOGGLE_VIEW]: { actions: 'assignAppView' },
 			[CHANGE_MINE]: {
 				target: 'loading',
 				actions: ['changeMine', 'stopAllActors', 'getApiTokenFromStorage'],
@@ -368,6 +384,7 @@ export const appManagerMachine = Machine(
 			setAppView,
 			fetchInitialSummaryForMine,
 			stopAllActors,
+			assignAppView,
 		},
 		services: {
 			fetchMineConfiguration,

--- a/src/components/App/overviewMachine.js
+++ b/src/components/App/overviewMachine.js
@@ -3,7 +3,7 @@ import {
 	FETCH_INITIAL_SUMMARY,
 	FETCH_OVERVIEW_SUMMARY,
 	FETCH_SUMMARY,
-	RESET_VIEW,
+	RESET_OVERVIEW,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
@@ -167,7 +167,7 @@ export const overviewMachine = Machine(
 						actions: ['assignLastOverviewQuery', 'fetchOverviewSummary'],
 					},
 					[CHANGE_CLASS]: { actions: 'resetLastOverviewQuery' },
-					[RESET_VIEW]: {
+					[RESET_OVERVIEW]: {
 						actions: [
 							'resetToInitialQuery',
 							'spawnConstraintActors',

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react'
 import { useWindowSize } from 'react-use'
 // use direct import because babel is not properly changing it in webpack
 import { useFirstMountState } from 'react-use/lib/useFirstMountState'
-import { FETCH_SUMMARY, TOGGLE_CATEGORY_VISIBILITY } from 'src/eventConstants'
+import { FETCH_SUMMARY, TOGGLE_CATEGORY_VISIBILITY, TOGGLE_VIEW } from 'src/eventConstants'
 import { sendToBus, useEventBus } from 'src/useEventBus'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
@@ -193,9 +193,14 @@ const OverviewConstraintList = ({ overviewActor }) => {
 	)
 }
 
-export const ConstraintSection = ({ templateViewActor, overviewActor, queryControllerActor }) => {
-	const [view, setView] = useState('defaultView')
-	const isTemplateView = view === 'templateView'
+export const ConstraintSection = ({
+	templateViewActor,
+	overviewActor,
+	queryControllerActor,
+	appView,
+}) => {
+	const isTemplateView = appView === 'templateView'
+	const [sendToBus] = useEventBus()
 
 	return (
 		<section
@@ -207,10 +212,12 @@ export const ConstraintSection = ({ templateViewActor, overviewActor, queryContr
 		>
 			<Tabs
 				id="constraint-tabs"
-				selectedTabId={view}
+				selectedTabId={appView}
 				large={true}
 				// @ts-ignore
-				onChange={setView}
+				onChange={(newTabId) => {
+					sendToBus({ type: TOGGLE_VIEW, newTabId })
+				}}
 				css={{
 					marginBottom: 10,
 					[`&& .${Classes.TAB_LIST}`]: { margin: '10px 20px 0' },

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -1,7 +1,7 @@
 import { Button, Navbar } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
-import { CHANGE_CLASS, RESET_VIEW } from 'src/eventConstants'
+import { CHANGE_CLASS, RESET_OVERVIEW, RESET_TEMPLATE_VIEW } from 'src/eventConstants'
 import { useEventBus, useServiceContext } from 'src/useEventBus'
 
 import { ClassSelector } from './ClassSelector'
@@ -13,7 +13,7 @@ import { MineSelector } from './MineSelector'
  */
 export const NavigationBar = () => {
 	const [state, send] = useServiceContext('appManager')
-	const { classView, modelClasses, listsForCurrentClass, selectedMine } = state.context
+	const { classView, modelClasses, listsForCurrentClass, selectedMine, appView } = state.context
 	const [sendToBus] = useEventBus()
 
 	const handleClassSelect = ({ name }) => {
@@ -36,12 +36,12 @@ export const NavigationBar = () => {
 					classView={classView}
 				/>
 				<Button
-					text="Reset all"
+					text="Reset view"
 					intent="danger"
 					icon={IconNames.ERROR}
 					css={{ marginLeft: 'auto' }}
 					onClick={() => {
-						sendToBus({ type: RESET_VIEW })
+						sendToBus({ type: appView === 'defaultView' ? RESET_OVERVIEW : RESET_TEMPLATE_VIEW })
 					}}
 				/>
 			</Navbar.Group>

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -95,7 +95,6 @@ export const TemplateQuery = ({ classView, template, rootUrl, mineName }) => {
 		})
 	)
 
-	console.log('here')
 	const [sendToBus] = useEventBus(service)
 
 	const {

--- a/src/components/Templates/templateQueryMachine.js
+++ b/src/components/Templates/templateQueryMachine.js
@@ -4,7 +4,7 @@ import {
 	FETCH_SUMMARY,
 	FETCH_TEMPLATE_SUMMARY,
 	REMOVE_LIST_CONSTRAINT,
-	RESET_VIEW,
+	RESET_TEMPLATE_VIEW,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
 import { assign, Machine, spawn } from 'xstate'
@@ -137,7 +137,7 @@ export const templateQueryMachine = Machine(
 					[FETCH_SUMMARY]: { actions: 'setActiveQuery' },
 					[ADD_LIST_CONSTRAINT]: { actions: 'addListConstraint' },
 					[REMOVE_LIST_CONSTRAINT]: { actions: 'removeListConstraint' },
-					[RESET_VIEW]: {
+					[RESET_TEMPLATE_VIEW]: {
 						actions: ['resetTemplate', 'spawnConstraintActors', 'resetTemplateSummary'],
 					},
 				},

--- a/src/eventConstants.js
+++ b/src/eventConstants.js
@@ -36,6 +36,9 @@ export const ADD_LIST_CONSTRAINT = 'appManager/lists/add'
 export const REMOVE_LIST_CONSTRAINT = 'appManager/lists/remove'
 export const SET_API_TOKEN = 'appManager/api/token'
 export const RESET_VIEW = 'appManager/reset/overview'
+export const RESET_OVERVIEW = 'appManager/reset/overview'
+export const RESET_TEMPLATE_VIEW = 'appManager/reset/templateView'
+export const TOGGLE_VIEW = 'appManager/view/toggle'
 
 /**
  * Table


### PR DESCRIPTION
This fixes a regression introduced by the last PR. The overview machine
is higher up the tree than the template query machines. So when resetting
the template view, the overview was also reset. This is remedied by
explicitly stating which view to reset.

Closes: #172 