### PR TITLE
Refactor: have children subscribe only to the relevant state

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -8,43 +8,36 @@ import React from 'react'
 import { useWindowSize } from 'react-use'
 import { AppManagerServiceContext, useEventBus } from 'src/useEventBus'
 
-import logo from '../../images/logo.png'
 import { BarChart } from '../BarChart/BarChart'
 import { ConstraintSection } from '../ConstraintSection/ConstraintSection'
 import { NavigationBar } from '../Navigation/NavigationBar'
 import { PieChart } from '../PieChart/PieChart'
 import { Table } from '../Table/Table'
 import { appManagerMachine } from './appManagerMachine'
+import { Header } from './Header'
 
 enableMapSet()
 
 export const App = () => {
-	const [state, send, service] = useMachine(appManagerMachine)
+	const [state, , service] = useMachine(appManagerMachine)
 	useEventBus(service)
 	const { height } = useWindowSize()
 
 	const { viewActors, appView } = state.context
 
+	// hack until https://github.com/davidkpiano/xstate/issues/938 is closed
+	// @ts-ignore
+	if (!state.initialized) {
+		service.start()
+	}
+
 	return (
 		<div className="light-theme">
-			<AppManagerServiceContext.Provider value={{ state, send }}>
-				<header css={{ display: 'inline-flex', width: '100%' }}>
-					<div
-						css={{
-							minWidth: '230px',
-							height: 43,
-							display: 'inline-flex',
-							alignItems: 'center',
-							justifyContent: 'center',
-							borderRight: '2px solid var(--blue5)',
-							borderBottom: '2px solid var(--blue5)',
-						}}
-					>
-						<img width="120px" src={logo} alt="Logo" />
-					</div>
+			<Header>
+				<AppManagerServiceContext.Provider value={service}>
 					<NavigationBar />
-				</header>
-			</AppManagerServiceContext.Provider>
+				</AppManagerServiceContext.Provider>
+			</Header>
 			<main css={{ display: 'grid', gridTemplateColumns: '230px 1fr' }}>
 				<ConstraintSection
 					templateViewActor={viewActors.templateView}
@@ -59,7 +52,9 @@ export const App = () => {
 					<section id="charts">
 						<Card css={{ height: '376px', marginBottom: '20px', display: 'flex' }}>
 							<div css={{ height: '100%', width: '45%' }}>
-								<PieChart />
+								<AppManagerServiceContext.Provider value={service}>
+									<PieChart />
+								</AppManagerServiceContext.Provider>
 							</div>
 							<div css={{ height: '100%', width: '45%' }}>
 								<BarChart />

--- a/src/components/App/Header.jsx
+++ b/src/components/App/Header.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import logo from '../../images/logo.png'
+
+export const Header = ({ children }) => {
+	return (
+		<header css={{ display: 'inline-flex', width: '100%' }}>
+			<div
+				css={{
+					minWidth: '230px',
+					height: 43,
+					display: 'inline-flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					borderRight: '2px solid var(--blue5)',
+					borderBottom: '2px solid var(--blue5)',
+				}}
+			>
+				<img width="120px" src={logo} alt="Logo" />
+			</div>
+			{children}
+		</header>
+	)
+}

--- a/src/components/App/templateViewMachine.js
+++ b/src/components/App/templateViewMachine.js
@@ -9,7 +9,7 @@ import {
 	TOGGLE_CATEGORY_VISIBILITY,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
-import { getTagCategories } from 'src/utils'
+import { getTagCategories, startActivity } from 'src/utils'
 import { assign, Machine } from 'xstate'
 
 /**
@@ -259,6 +259,7 @@ export const templateViewMachine = Machine(
 			},
 			errorFetchingTemplates: {},
 			loadTemplates: {
+				activities: ['isLoading'],
 				invoke: {
 					id: 'fetchTemplates',
 					src: 'fetchTemplates',
@@ -296,6 +297,9 @@ export const templateViewMachine = Machine(
 			resetLastTemplateQuery,
 			// @ts-ignore
 			fetchTemplateSummary,
+		},
+		activities: {
+			isLoading: startActivity,
 		},
 		guards: {
 			// @ts-ignore

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -62,7 +62,7 @@ export const BarChart = React.memo(function BarChart() {
 
 	const { lengthSummary, lengthStats } = state.context
 
-	const isLoading = !state.matches('idle')
+	const { isLoading } = state.activities
 	const summary = isLoading ? barChartLoadingData : lengthSummary
 
 	const { max, min, buckets, uniqueValues, average, stdev } = lengthStats
@@ -89,7 +89,7 @@ export const BarChart = React.memo(function BarChart() {
 		}
 	})
 
-	if (state.matches('noGeneLengths')) {
+	if (state.activities.hasNoValues) {
 		const title = isFirstRender ? 'No query has been executed' : 'No Gene lengths available'
 		const description = isFirstRender
 			? 'Define the constraints to the left, and execute a query to see visual data results'

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -4,17 +4,13 @@ import { barChartCache } from 'src/caches'
 import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
 import { assign, Machine } from 'xstate'
 
-import { logErrorToConsole } from '../../utils'
+import { logErrorToConsole, startActivity } from '../../utils'
 
 const setLengthSummary = assign({
 	// @ts-ignore
 	lengthStats: (_, { data }) => data.lengthStats,
 	// @ts-ignore
 	lengthSummary: (_, { data }) => data.lengthSummary,
-	// @ts-ignore
-	classView: (_, { data }) => data.classView,
-	// @ts-ignore
-	rootUrl: (_, { data }) => data.rootUrl,
 })
 
 export const BarChartMachine = Machine(
@@ -31,8 +27,6 @@ export const BarChartMachine = Machine(
 				stdev: 0,
 			},
 			lengthSummary: [],
-			classView: '',
-			rootUrl: '',
 		},
 		on: {
 			[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
@@ -49,6 +43,7 @@ export const BarChartMachine = Machine(
 				on: {
 					[FETCH_INITIAL_SUMMARY]: { target: 'loading' },
 				},
+				activities: ['isLoading'],
 			},
 			loading: {
 				invoke: {
@@ -68,6 +63,7 @@ export const BarChartMachine = Machine(
 				on: {
 					[FETCH_SUMMARY]: { target: 'loading' },
 				},
+				activities: ['hasNoValues'],
 			},
 		},
 	},
@@ -75,6 +71,10 @@ export const BarChartMachine = Machine(
 		actions: {
 			setLengthSummary,
 			logErrorToConsole,
+		},
+		activities: {
+			isLoading: startActivity,
+			hasNoValues: startActivity,
 		},
 		guards: {
 			hasNoSummary: (ctx) => {

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -80,7 +80,7 @@ const TemplatesList = ({
 		lastTemplateQuery,
 	} = state.context
 
-	const isLoading = state.matches('loadTemplates')
+	const { isLoading } = state.activities
 
 	const [sendToBus] = useEventBus(service)
 	const isFirstMount = useFirstMountState()

--- a/src/components/Navigation/ClassSelector.jsx
+++ b/src/components/Navigation/ClassSelector.jsx
@@ -3,6 +3,8 @@ import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
 import React, { useEffect, useRef } from 'react'
 import { buildSearchIndex } from 'src/buildSearchIndex'
+import { CHANGE_CLASS } from 'src/eventConstants'
+import { usePartialContext } from 'src/useEventBus'
 import { pluralizeFilteredCount } from 'src/utils'
 
 import { NumberedSelectMenuItems } from '../Shared/Selects'
@@ -11,6 +13,7 @@ import { NumberedSelectMenuItems } from '../Shared/Selects'
  */
 const renderMenu = ({ filteredItems, itemsParentRef, query, renderItem }) => {
 	const renderedItems = filteredItems.map(renderItem)
+
 	const infoText = pluralizeFilteredCount(filteredItems, query)
 
 	return (
@@ -21,11 +24,23 @@ const renderMenu = ({ filteredItems, itemsParentRef, query, renderItem }) => {
 	)
 }
 
-export const ClassSelector = ({ handleClassSelect, modelClasses, classView, mineName }) => {
+export const ClassSelector = () => {
+	const [state, sendToAppManager] = usePartialContext('appManager', (ctx) => ({
+		modelClasses: ctx.modelClasses,
+		classView: ctx.classView,
+		mineName: ctx.selectedMine.name,
+	}))
+
+	const { modelClasses, classView, mineName } = state
+
 	const classSearchIndex = useRef(null)
 
 	const classDisplayName =
 		modelClasses.find((model) => model.name === classView)?.displayName ?? 'Gene'
+
+	const handleClassSelect = ({ name }) => {
+		sendToAppManager({ type: CHANGE_CLASS, newClass: name })
+	}
 
 	useEffect(() => {
 		const indexClasses = async () => {

--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { usePrevious } from 'react-use'
 import { buildSearchIndex } from 'src/buildSearchIndex'
 import { ADD_LIST_CONSTRAINT, REMOVE_LIST_CONSTRAINT } from 'src/eventConstants'
-import { useEventBus } from 'src/useEventBus'
+import { useEventBus, usePartialContext } from 'src/useEventBus'
 import { pluralizeFilteredCount } from 'src/utils'
 
 import { ConstraintSetTag } from '../Shared/ConstraintSetTag'
@@ -57,10 +57,19 @@ const renderMenu = (selectedValue) => ({ filteredItems, itemsParentRef, query, r
 	)
 }
 
-export const ListSelector = ({ listsForCurrentClass, mineName, classView }) => {
+export const ListSelector = () => {
+	const [state] = usePartialContext('appManager', (ctx) => ({
+		mineName: ctx.selectedMine.name,
+		classView: ctx.classView,
+		listsForCurrentClass: ctx.listsForCurrentClass,
+	}))
+
+	const { mineName, classView, listsForCurrentClass } = state
+	const [sendToBus] = useEventBus()
+
 	const listSearchIndex = useRef(null)
 	const [selectedValue, setSelectedValue] = useState('')
-	const [sendToBus] = useEventBus()
+
 	const prevMineName = usePrevious(mineName)
 	const prevClassView = usePrevious(classView)
 

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -3,32 +3,38 @@ import { IconNames } from '@blueprintjs/icons'
 import { Select } from '@blueprintjs/select'
 import React, { useEffect, useState } from 'react'
 import { CHANGE_MINE, SET_API_TOKEN } from 'src/eventConstants'
-import { useEventBus, useServiceContext } from 'src/useEventBus'
+import { useEventBus, usePartialContext } from 'src/useEventBus'
 
 import { NumberedSelectMenuItems } from '../Shared/Selects'
 
 export const MineSelector = () => {
-	const [state, send] = useServiceContext('appManager')
+	const [state, sendToAppManager] = usePartialContext('appManager', (ctx) => ({
+		apiToken: ctx.selectedMine.apiToken,
+		rootUrl: ctx.selectedMine.rootUrl,
+		intermines: ctx.intermines,
+		mineName: ctx.selectedMine.name,
+	}))
+
 	const [showPopup, setShowPopup] = useState(false)
 	const [sendToBus] = useEventBus()
 
-	const { selectedMine, intermines } = state.context
-	const [apiToken, setApiToken] = useState(selectedMine.apiToken)
-	const [currentMine, setCurrentMine] = useState(selectedMine.rootUrl)
+	const { apiToken: token, rootUrl, intermines, mineName } = state
+	const [apiToken, setApiToken] = useState(token)
+	const [currentMine, setCurrentMine] = useState(rootUrl)
 
 	useEffect(() => {
-		if (currentMine !== selectedMine.rootUrl) {
-			setCurrentMine(selectedMine.rootUrl)
-			setApiToken(selectedMine.apiToken)
+		if (currentMine !== rootUrl) {
+			setCurrentMine(rootUrl)
+			setApiToken(apiToken)
 		}
-	}, [currentMine, selectedMine.rootUrl, selectedMine.apiToken])
+	}, [apiToken, currentMine, rootUrl])
 
 	const handleMineChange = ({ name }) => {
 		// @ts-ignore
 		sendToBus({ type: CHANGE_MINE, newMine: name })
 	}
 
-	const isAuthenticated = selectedMine.apiToken.length > 0
+	const isAuthenticated = apiToken.length > 0
 
 	return (
 		<>
@@ -59,7 +65,7 @@ export const MineSelector = () => {
 						// used to override `Blueprintjs` styles for a small button
 						style={{ minWidth: 166 }}
 						small={true}
-						text={selectedMine.name}
+						text={mineName}
 						alignText="left"
 						rightIcon={IconNames.CARET_DOWN}
 					/>
@@ -81,7 +87,7 @@ export const MineSelector = () => {
 					Key
 				</span>
 				<Popover
-					onClose={() => send({ type: SET_API_TOKEN, apiToken })}
+					onClose={() => sendToAppManager({ type: SET_API_TOKEN, apiToken })}
 					isOpen={showPopup}
 					onInteraction={(nextState) => setShowPopup(nextState)}
 				>

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -1,8 +1,8 @@
 import { Button, Navbar } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
-import { CHANGE_CLASS, RESET_OVERVIEW, RESET_TEMPLATE_VIEW } from 'src/eventConstants'
-import { useEventBus, useServiceContext } from 'src/useEventBus'
+import { RESET_OVERVIEW, RESET_TEMPLATE_VIEW } from 'src/eventConstants'
+import { useEventBus, usePartialContext } from 'src/useEventBus'
 
 import { ClassSelector } from './ClassSelector'
 import { ListSelector } from './ListSelector'
@@ -12,36 +12,27 @@ import { MineSelector } from './MineSelector'
  *
  */
 export const NavigationBar = () => {
-	const [state, send] = useServiceContext('appManager')
-	const { classView, modelClasses, listsForCurrentClass, selectedMine, appView } = state.context
-	const [sendToBus] = useEventBus()
+	const [state] = usePartialContext('appManager', (ctx) => ({
+		appView: ctx.appView,
+	}))
 
-	const handleClassSelect = ({ name }) => {
-		send({ type: CHANGE_CLASS, newClass: name })
-	}
+	const [sendToBus] = useEventBus()
 
 	return (
 		<Navbar css={{ padding: '0 40px' }}>
 			<Navbar.Group css={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
 				<MineSelector />
-				<ClassSelector
-					handleClassSelect={handleClassSelect}
-					modelClasses={modelClasses}
-					classView={classView}
-					mineName={selectedMine.name}
-				/>
-				<ListSelector
-					listsForCurrentClass={listsForCurrentClass}
-					mineName={selectedMine.name}
-					classView={classView}
-				/>
+				<ClassSelector />
+				<ListSelector />
 				<Button
 					text="Reset view"
 					intent="danger"
 					icon={IconNames.ERROR}
 					css={{ marginLeft: 'auto' }}
 					onClick={() => {
-						sendToBus({ type: appView === 'defaultView' ? RESET_OVERVIEW : RESET_TEMPLATE_VIEW })
+						sendToBus({
+							type: state.appView === 'defaultView' ? RESET_OVERVIEW : RESET_TEMPLATE_VIEW,
+						})
 					}}
 				/>
 			</Navbar.Group>

--- a/src/components/Overview/OverviewConstraint.jsx
+++ b/src/components/Overview/OverviewConstraint.jsx
@@ -150,36 +150,29 @@ export const OverviewConstraint = ({ color, overviewConstraintActor }) => {
 			break
 	}
 
-	const disableAllButtons =
-		state.matches('noConstraintsSet') ||
-		state.matches('loading') ||
-		state.matches('noConstraintItems')
-
-	const enableApplyButton = state.matches('constraintsUpdated')
-
-	/**
-	 * This is used to decide the color for the count tag. Since it will only
-	 * ever be displayed when a constraint is actually set, we only care to know if
-	 * it has been updated so we can change its color.
-	 */
-	const isUpdated = state.matches('constraintsUpdated')
+	const { disablingButtons, waitingToApplyContraint } = state.activities
 
 	const handleOnClick = (type) => send({ type })
 
 	return (
-		<ConstraintServiceContext.Provider value={{ state, send }}>
+		<ConstraintServiceContext.Provider value={service}>
 			<PopupCard boundary="viewport">
 				<ConstraintButton
 					label={label}
 					color={color}
 					name={name}
 					constraintCount={constraintCount}
-					isUpdated={isUpdated}
+					/**
+					 * This is used to decide the color for the count tag. Since it will only
+					 * ever be displayed when a constraint is actually set, we only care to know if
+					 * it has been updated so we can change its color.
+					 */
+					isUpdated={waitingToApplyContraint}
 				/>
 				<div>
 					<ConstraintCard
-						disableAllButtons={disableAllButtons}
-						enableApplyButton={enableApplyButton}
+						disableAllButtons={disablingButtons}
+						enableApplyButton={waitingToApplyContraint}
 						handleOnClick={handleOnClick}
 					>
 						<ConstraintWidget

--- a/src/components/Overview/overviewConstraintMachine.js
+++ b/src/components/Overview/overviewConstraintMachine.js
@@ -13,7 +13,7 @@ import {
 	RESET_OVERVIEW_CONSTRAINT,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
-import { formatConstraintPath } from 'src/utils'
+import { formatConstraintPath, startActivity } from 'src/utils'
 import { assign, Machine } from 'xstate'
 
 import { logErrorToConsole } from '../../utils'
@@ -108,9 +108,13 @@ export const overviewConstraintMachine = Machine(
 						actions: 'logErrorToConsole',
 					},
 				},
+				activities: ['isLoading', 'disablingButtons'],
 			},
-			noConstraintItems: {},
+			noConstraintItems: {
+				activities: ['hasNoValues', 'disablingButtons'],
+			},
 			noConstraintsSet: {
+				activities: ['disablingButtons'],
 				always: [{ target: 'noConstraintItems', cond: 'hasNoConstraintItems' }],
 				entry: 'resetConstraint',
 				on: {
@@ -121,6 +125,7 @@ export const overviewConstraintMachine = Machine(
 				},
 			},
 			constraintsUpdated: {
+				activities: ['waitingToApplyContraint'],
 				always: [{ target: 'noConstraintsSet', cond: 'selectedListIsEmpty' }],
 				on: {
 					[ADD_CONSTRAINT]: { actions: 'addConstraint' },
@@ -159,6 +164,12 @@ export const overviewConstraintMachine = Machine(
 			setAvailableValues,
 			applyOverviewConstraint,
 			resetConstraint,
+		},
+		activities: {
+			isLoading: startActivity,
+			disablingButtons: startActivity,
+			waitingToApplyContraint: startActivity,
+			hasNoValues: startActivity,
 		},
 		guards: {
 			selectedListIsEmpty: (ctx) => {

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -14,7 +14,7 @@ import {
 	Tooltip,
 } from 'recharts'
 import { blinkingSkeletonAnimation } from 'src/styleUtils'
-import { useEventBus } from 'src/useEventBus'
+import { useEventBus, usePartialContext } from 'src/useEventBus'
 import { pieChartLoadingData } from 'src/utils/loadingData/pieChartData'
 
 import { DATA_VIZ_COLORS } from '../dataVizColors'
@@ -63,15 +63,21 @@ const renderLoadingLabel = (props) => {
 
 export const PieChart = React.memo(function PieChart() {
 	const isFirstRender = useFirstMountState()
+
 	const [state, , service] = useMachine(PieChartMachine)
+	const [appState] = usePartialContext('appManager', (ctx) => ({
+		classView: ctx.classView,
+	}))
+
 	useEventBus(service)
 
-	const { allClassOrganisms, classView } = state.context
+	const { allClassOrganisms } = state.context
+	const { classView } = appState
 
-	const isLoading = !state.matches('idle')
+	const { isLoading, hasNoValues } = state.activities
 	const data = isLoading ? pieChartLoadingData : allClassOrganisms
 
-	if (state.matches('hasNoSummary')) {
+	if (hasNoValues) {
 		const title = isFirstRender ? 'No query has been executed' : 'No Organism Summary available'
 		const description = isFirstRender
 			? 'Define the constraints to the left, and execute a query to see visual data results'

--- a/src/components/Table/TablePagingButtons.jsx
+++ b/src/components/Table/TablePagingButtons.jsx
@@ -3,7 +3,7 @@ import { IconNames } from '@blueprintjs/icons'
 import React, { useEffect, useState } from 'react'
 import { useDebounce } from 'react-use'
 import { CHANGE_PAGE } from 'src/eventConstants'
-import { useServiceContext } from 'src/useEventBus'
+import { usePartialContext } from 'src/useEventBus'
 
 const RowCount = ({ pageNumber, visibleRows, totalRows, isLoading }) => {
 	const previousPage = pageNumber - 1
@@ -35,11 +35,16 @@ const RowCount = ({ pageNumber, visibleRows, totalRows, isLoading }) => {
  *
  */
 export const TablePagingButtons = () => {
-	const [state, send] = useServiceContext('table')
-	const [pageNumber, setPageNumber] = useState(1)
+	const [state, send, service] = usePartialContext('table', (ctx) => ({
+		pageInMachine: ctx.pageNumber,
+		visibleRows: ctx.visibleRows,
+		totalRows: ctx.totalRows,
+	}))
 
-	const { pageNumber: pageInMachine, visibleRows, totalRows } = state.context
-	const isLoading = !state.matches('idle')
+	const [pageNumber, setPageNumber] = useState(1)
+	const { pageInMachine, visibleRows, totalRows } = state
+
+	const { isLoading } = service.state.activities
 
 	useEffect(() => {
 		setPageNumber(pageInMachine)

--- a/src/components/Table/tableChartMachine.js
+++ b/src/components/Table/tableChartMachine.js
@@ -9,6 +9,7 @@ import {
 	SET_AVAILABLE_COLUMNS,
 } from 'src/eventConstants'
 import { sendToBus } from 'src/useEventBus'
+import { startActivity } from 'src/utils'
 import { assign, Machine } from 'xstate'
 
 const bustCachedPages = assign({
@@ -18,8 +19,6 @@ const bustCachedPages = assign({
 const setInitialRows = assign({
 	// @ts-ignore
 	rootUrl: (_, { data }) => data.rootUrl,
-	// @ts-ignore
-	classView: (_, { data }) => data.classView,
 	// @ts-ignore
 	totalRows: (_, { data }) => data.totalRows,
 	// @ts-ignore
@@ -78,7 +77,6 @@ export const TableChartMachine = Machine(
 			pages: new Map(),
 			lastQuery: {},
 			rootUrl: '',
-			classView: '',
 		},
 		on: {
 			[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
@@ -119,6 +117,7 @@ export const TableChartMachine = Machine(
 						actions: (ctx, event) => console.error('FETCH: Loading Table Rows', { ctx, event }),
 					},
 				},
+				activities: ['isLoading'],
 			},
 			fetchNewPages: {
 				invoke: {
@@ -134,6 +133,7 @@ export const TableChartMachine = Machine(
 							console.error('FETCH: Could not fetch new Table Rows', { ctx, event }),
 					},
 				},
+				activities: ['isLoading'],
 			},
 			noTableSummary: {
 				on: {
@@ -142,6 +142,7 @@ export const TableChartMachine = Machine(
 						actions: 'bustCachedPages',
 					},
 				},
+				activities: ['hasNoValues'],
 			},
 		},
 	},
@@ -152,6 +153,10 @@ export const TableChartMachine = Machine(
 			setLastQuery,
 			refreshCache,
 			updatePageNumber,
+		},
+		activities: {
+			isLoading: startActivity,
+			hasNoValues: startActivity,
 		},
 		guards: {
 			hasNoTableSummary: (ctx) => {
@@ -202,7 +207,6 @@ export const TableChartMachine = Machine(
 				sendToBus({ type: SET_AVAILABLE_COLUMNS, selectedPaths: headers })
 
 				return {
-					classView,
 					rootUrl,
 					totalRows,
 					query,

--- a/src/components/Templates/TemplateQuery.jsx
+++ b/src/components/Templates/TemplateQuery.jsx
@@ -58,7 +58,7 @@ const ConstraintWidget = ({ templateConstraintActor, mineName }) => {
 	}
 
 	return (
-		<ConstraintServiceContext.Provider value={{ state, send }}>
+		<ConstraintServiceContext.Provider value={service}>
 			<div css={{ margin: '20px 0' }}>
 				<H5>{name}</H5>
 				<ConstraintWidget
@@ -127,7 +127,7 @@ export const TemplateQuery = ({ classView, template, rootUrl, mineName }) => {
 	}
 
 	const disableRunQuery = constraintActors.some((actor) => {
-		return actor.state.matches('noValuesSelected')
+		return actor.state.activities.waitingForSelection
 	})
 
 	return (

--- a/src/components/Widgets/CheckboxWidget.jsx
+++ b/src/components/Widgets/CheckboxWidget.jsx
@@ -1,14 +1,17 @@
 import { Checkbox, Label } from '@blueprintjs/core'
 import React from 'react'
 import { ADD_CONSTRAINT, REMOVE_CONSTRAINT } from 'src/eventConstants'
-import { useServiceContext } from 'src/useEventBus'
+import { usePartialContext } from 'src/useEventBus'
 
 import { NoValuesProvided } from '../Shared/NoValuesProvided'
 
 export const CheckboxWidget = ({ nonIdealTitle = undefined, nonIdealDescription = undefined }) => {
-	const [state, send] = useServiceContext('constraints')
+	const [state, sendToConstraintMachine] = usePartialContext('constraints', (ctx) => ({
+		availableValues: ctx.availableValues,
+		selectedValues: ctx.selectedValues,
+	}))
 
-	const { availableValues, selectedValues } = state?.context
+	const { availableValues, selectedValues } = state
 
 	if (availableValues?.length === 0) {
 		return <NoValuesProvided title={nonIdealTitle} description={nonIdealDescription} />
@@ -16,9 +19,9 @@ export const CheckboxWidget = ({ nonIdealTitle = undefined, nonIdealDescription 
 
 	const onChangeHandler = (constraint) => (e) => {
 		if (e.target.checked) {
-			send({ type: ADD_CONSTRAINT, constraint })
+			sendToConstraintMachine({ type: ADD_CONSTRAINT, constraint })
 		} else {
-			send({ type: REMOVE_CONSTRAINT, constraint })
+			sendToConstraintMachine({ type: REMOVE_CONSTRAINT, constraint })
 		}
 	}
 

--- a/src/components/Widgets/InputWidget.jsx
+++ b/src/components/Widgets/InputWidget.jsx
@@ -1,12 +1,12 @@
 import { InputGroup } from '@blueprintjs/core'
 import React from 'react'
 import { ADD_CONSTRAINT } from 'src/eventConstants'
-import { useServiceContext } from 'src/useEventBus'
+import { usePartialContext } from 'src/useEventBus'
 
 export const InputWidget = ({ operationLabel }) => {
-	const [state, send] = useServiceContext('constraints')
-
-	const { selectedValues } = state.context
+	const [state, sendToConstraintMachine] = usePartialContext('constraints', (ctx) => ({
+		selectedValues: ctx.selectedValues,
+	}))
 
 	return (
 		<div css={{ display: 'flex' }}>
@@ -26,8 +26,10 @@ export const InputWidget = ({ operationLabel }) => {
 			</div>
 			<InputGroup
 				fill={true}
-				value={selectedValues[0]}
-				onChange={(e) => send({ type: ADD_CONSTRAINT, constraint: e.target.value })}
+				value={state.selectedValues[0]}
+				onChange={(e) =>
+					sendToConstraintMachine({ type: ADD_CONSTRAINT, constraint: e.target.value })
+				}
 			/>
 		</div>
 	)

--- a/src/components/Widgets/SelectWidget.jsx
+++ b/src/components/Widgets/SelectWidget.jsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { operationsDict } from 'src/constraintOperations'
 import { ADD_CONSTRAINT } from 'src/eventConstants'
 import { generateId } from 'src/generateId'
-import { useServiceContext } from 'src/useEventBus'
+import { usePartialContext } from 'src/useEventBus'
 
 const renderItems = (item, { handleClick, modifiers }) => {
 	if (!modifiers.matchesPredicate) {
@@ -19,11 +19,16 @@ const renderItems = (item, { handleClick, modifiers }) => {
 
 export const SelectWidget = () => {
 	const [uniqueId] = useState(() => `selectWidget-${generateId()}`)
-	const [state, send] = useServiceContext('constraints')
-	const { availableValues, constraint, selectedValues } = state.context
+	const [state, sendToConstraintMachine] = usePartialContext('constraints', (ctx) => ({
+		availableValues: ctx.availableValues,
+		constraint: ctx.constraint,
+		selectedValues: ctx.selectedValues,
+	}))
+
+	const { availableValues, constraint, selectedValues } = state
 
 	const handleItemSelect = ({ value }) => {
-		send({ type: ADD_CONSTRAINT, constraint: value })
+		sendToConstraintMachine({ type: ADD_CONSTRAINT, constraint: value })
 	}
 
 	return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,9 @@
 export const noop = () => {}
 
+export const startActivity = () => {
+	return noop
+}
+
 export const formatConstraintPath = ({ classView, path }) => `${classView}.${path}`
 
 export const pluralizeFilteredCount = (filteredItems, query) => {
@@ -13,7 +17,7 @@ export const pluralizeFilteredCount = (filteredItems, query) => {
 export const getTagCategories = (tags) => {
 	const categories = []
 
-	for (let i = 0; i < tags.length; i++) {
+	for (let i = 0; i < tags?.length; i++) {
 		if (tags[i].indexOf('im:aspect') > -1) {
 			categories.push(tags[i].replace('im:aspect:', ''))
 		}


### PR DESCRIPTION
Children components are currently receiving the full state object from
the parent machines. This leads to unnecessary re-renders. Instead, those
services should only render when the state they require updates. This
PR makes these children register to the relevant state using a
custom hook.

I also refactored the the usage of `state.matches`, since components
should not have any awareness of the state node that the machine is in.

Closes: #174 