### PR TITLE
Fix: decrease memory consumption

### DIFF
--- a/src/buildSearchIndex.js
+++ b/src/buildSearchIndex.js
@@ -7,8 +7,8 @@ import { indexWorker } from './searchIndex'
 export const buildSearchIndex = async ({ docId, docField, values, query }) => {
 	// The configuration *must* be the same for import and export
 	const indexConfig = {
-		encode: 'advanced',
-		tokenize: 'reverse',
+		encode: 'extra',
+		tokenize: 'forward',
 		suggest: true,
 		cache: true,
 		doc: {


### PR DESCRIPTION
The app was taking 500-600mb of memory according to chrome's task
manager, and the heap was reading close to 200mb. This happened because
of the size of the search indexes. Since the search is only used for direct
matches, decreasing the encoder specificity and the tokenizer to index only
forward decreased the heap to 70mb and the tab to 200mb.

Closes: #176 