### PR TITLE
Add attribute headers to table exports

### DIFF
--- a/src/components/Table/ExportTableButton.jsx
+++ b/src/components/Table/ExportTableButton.jsx
@@ -7,7 +7,7 @@ import { exportTable } from 'src/apiRequests'
 /**
  *
  */
-export const ExportTableButton = ({ query, rootUrl }) => {
+export const ExportTableButton = ({ query, rootUrl, headers }) => {
 	const [isOpen, setIsOpen] = useState(false)
 	const [format, setFormat] = useState('tsv')
 	const [fileName, setFileName] = useState('table data result')
@@ -17,7 +17,7 @@ export const ExportTableButton = ({ query, rootUrl }) => {
 
 	const handleExport = async () => {
 		try {
-			await exportTable({ query, rootUrl, format, fileName })
+			await exportTable({ query, rootUrl, format, fileName, headers })
 		} catch (e) {
 			// Todo: display an error message
 			setErrorDownloading(true)

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -79,7 +79,7 @@ export const Table = React.memo(function Table() {
 		service.start()
 	}
 
-	const { pages, rootUrl, pageNumber, lastQuery } = state.context
+	const { pages, rootUrl, pageNumber, lastQuery, headers } = state.context
 	const { isLoading, hasNoValues } = service.state.activities
 
 	const rows = isLoading
@@ -105,14 +105,14 @@ export const Table = React.memo(function Table() {
 				}}
 			>
 				<GenerateCodeButton query={lastQuery} rootUrl={rootUrl} />
-				<ExportTableButton query={lastQuery} rootUrl={rootUrl} />
+				<ExportTableButton query={lastQuery} rootUrl={rootUrl} headers={headers} />
 			</div>
 			<TablePagingButtons />
 			<HTMLTable css={{ width: '100%' }} interactive={true} striped={true}>
 				<thead>
 					<tr>
-						{rows[0].map((r) => {
-							return <ColumnHeader isLoading={isLoading} key={r.column} columnName={r.column} />
+						{headers.map((header) => {
+							return <ColumnHeader isLoading={isLoading} key={header} columnName={header} />
 						})}
 					</tr>
 				</thead>

--- a/src/components/Table/tableChartMachine.js
+++ b/src/components/Table/tableChartMachine.js
@@ -18,6 +18,8 @@ const bustCachedPages = assign({
 
 const setInitialRows = assign({
 	// @ts-ignore
+	headers: (_, { data }) => data.headers,
+	// @ts-ignore
 	rootUrl: (_, { data }) => data.rootUrl,
 	// @ts-ignore
 	totalRows: (_, { data }) => data.totalRows,
@@ -77,6 +79,7 @@ export const TableChartMachine = Machine(
 			pages: new Map(),
 			lastQuery: {},
 			rootUrl: '',
+			headers: [],
 		},
 		on: {
 			[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
@@ -207,6 +210,7 @@ export const TableChartMachine = Machine(
 				sendToBus({ type: SET_AVAILABLE_COLUMNS, selectedPaths: headers })
 
 				return {
+					headers,
 					rootUrl,
 					totalRows,
 					query,


### PR DESCRIPTION
This PR adds the table headers to the tsv and csv exports. It does
not account for paging, and only sets the headers to the top of the file.

Closes: #178 