### PR TITLE
Fix: downloading generated code

### DIFF
--- a/src/components/Table/GenerateCodeButton.jsx
+++ b/src/components/Table/GenerateCodeButton.jsx
@@ -170,9 +170,10 @@ const GenerateCodeDialog = ({ lang, handleDialogClose, isOpen, query, rootUrl, s
 			fetchCodePreview()
 		}
 	})
+
 	const handleFileSave = () => {
-		const blob = new Blob([code[lang].plain])
-		saveAs(blob, `${fileName}.${codeNameToExtension(lang)}`)
+		const blob = new Blob([code[fileExtension].plain])
+		saveAs(blob, `${fileName}.${fileExtension}`)
 	}
 
 	const renderCode = code[fileExtension] || code[previousFileExtension]


### PR DESCRIPTION
The generated code was saved under the file extension, yet was being
accessed using the full language name. So an error was being logged to
the console and the file would not save. This commit accesses the
generated code using the file extension to fix this.

Closes: #180 