### PR TITLE
Fix: navigation buttons squish when shrinking the page

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -47,10 +47,17 @@ export const App = () => {
 				/>
 				<section
 					id="data-viz"
-					css={{ padding: '10px 30px 0', overflow: 'auto', height: 'calc(100vh - 3.643em)' }}
+					css={{
+						padding: '10px 30px 0',
+						overflow: 'auto',
+						height: 'calc(100vh - 100px)',
+						'@media (min-width: 1157px)': {
+							height: 'calc(100vh - 20px)',
+						},
+					}}
 				>
 					<section id="charts">
-						<Card css={{ height: '376px', marginBottom: '20px', display: 'flex' }}>
+						<Card css={{ height: '376px', marginBottom: '10px', display: 'flex' }}>
 							<div css={{ height: '100%', width: '45%' }}>
 								<AppManagerServiceContext.Provider value={service}>
 									<PieChart />

--- a/src/components/App/Header.jsx
+++ b/src/components/App/Header.jsx
@@ -8,7 +8,6 @@ export const Header = ({ children }) => {
 			<div
 				css={{
 					minWidth: '230px',
-					height: 43,
 					display: 'inline-flex',
 					alignItems: 'center',
 					justifyContent: 'center',

--- a/src/components/Navigation/ClassSelector.jsx
+++ b/src/components/Navigation/ClassSelector.jsx
@@ -67,7 +67,7 @@ export const ClassSelector = () => {
 	}
 
 	return (
-		<div css={{ display: 'flex', marginLeft: 100, marginRight: 20 }}>
+		<div css={{ display: 'flex' }}>
 			<span
 				// @ts-ignore
 				css={{

--- a/src/components/Navigation/ListSelector.jsx
+++ b/src/components/Navigation/ListSelector.jsx
@@ -129,7 +129,7 @@ export const ListSelector = () => {
 	}
 
 	return (
-		<div css={{ display: 'flex', alignItems: 'center', marginLeft: 40, marginRight: 20 }}>
+		<div css={{ display: 'flex', alignItems: 'center' }}>
 			<span
 				// @ts-ignore
 				css={{

--- a/src/components/Navigation/MineSelector.jsx
+++ b/src/components/Navigation/MineSelector.jsx
@@ -37,11 +37,11 @@ export const MineSelector = () => {
 	const isAuthenticated = apiToken.length > 0
 
 	return (
-		<>
+		<div css={{ display: 'flex' }}>
 			{/* 
 					mine selection
 		  */}
-			<div css={{ display: 'flex', alignItems: 'center' }}>
+			<div css={{ display: 'flex', alignItems: 'center', margin: '10px 0' }}>
 				<span
 					// @ts-ignore
 					css={{
@@ -54,7 +54,6 @@ export const MineSelector = () => {
 					Mine
 				</span>
 				<Select
-					css={{ marginRight: 30 }}
 					items={intermines}
 					filterable={false}
 					itemRenderer={NumberedSelectMenuItems}
@@ -74,7 +73,7 @@ export const MineSelector = () => {
 			{/* 
 			       Api Status
 			 */}
-			<div css={{ display: 'flex', alignItems: 'center' }}>
+			<div css={{ display: 'flex', alignItems: 'center', marginLeft: 20 }}>
 				<span
 					// @ts-ignore
 					css={{
@@ -114,6 +113,6 @@ export const MineSelector = () => {
 					/>
 				</Popover>
 			</div>
-		</>
+		</div>
 	)
 }

--- a/src/components/Navigation/NavigationBar.jsx
+++ b/src/components/Navigation/NavigationBar.jsx
@@ -19,8 +19,17 @@ export const NavigationBar = () => {
 	const [sendToBus] = useEventBus()
 
 	return (
-		<Navbar css={{ padding: '0 40px' }}>
-			<Navbar.Group css={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+		<Navbar css={{ padding: '0 40px', height: 'auto' }}>
+			<Navbar.Group
+				css={{
+					width: '100%',
+					display: 'flex',
+					flexWrap: 'wrap',
+					justifyContent: 'space-evenly',
+					height: 'auto',
+					minHeight: 42,
+				}}
+			>
 				<MineSelector />
 				<ClassSelector />
 				<ListSelector />
@@ -28,7 +37,7 @@ export const NavigationBar = () => {
 					text="Reset view"
 					intent="danger"
 					icon={IconNames.ERROR}
-					css={{ marginLeft: 'auto' }}
+					css={{ margin: '10px 0' }}
 					onClick={() => {
 						sendToBus({
 							type: state.appView === 'defaultView' ? RESET_OVERVIEW : RESET_TEMPLATE_VIEW,


### PR DESCRIPTION
When shrinking the page, the navigation buttons shrink. Although full
mobile responsiveness is being pushed into a future story, because it will
require a mobile layout design this is still not ideal even for desktops.
Now the navigation bar and the table are mobile responsive down to about
iPad pro tablet sizes.

Closes: #184 