### PR TITLE
Fix: the charts not exiting error states

### DIFF
--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchSummary } from 'src/apiRequests'
 import { barChartCache } from 'src/caches'
-import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
+import { CHANGE_CLASS, CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
 import { assign, Machine } from 'xstate'
 
 import { logErrorToConsole, startActivity } from '../../utils'
@@ -46,6 +46,7 @@ export const BarChartMachine = Machine(
 				activities: ['isLoading'],
 			},
 			loading: {
+				activities: ['isLoading'],
 				invoke: {
 					id: 'fetchGeneLength',
 					src: 'fetchGeneLength',
@@ -62,6 +63,8 @@ export const BarChartMachine = Machine(
 			noGeneLengths: {
 				on: {
 					[FETCH_SUMMARY]: { target: 'loading' },
+					[CHANGE_CLASS]: { target: 'idle' },
+					[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
 				},
 				activities: ['hasNoValues'],
 			},

--- a/src/components/PieChart/pieChartMachine.js
+++ b/src/components/PieChart/pieChartMachine.js
@@ -1,7 +1,7 @@
 import hash from 'object-hash'
 import { fetchSummary } from 'src/apiRequests'
 import { pieChartCache } from 'src/caches'
-import { CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
+import { CHANGE_CLASS, CHANGE_MINE, FETCH_INITIAL_SUMMARY, FETCH_SUMMARY } from 'src/eventConstants'
 import { startActivity } from 'src/utils'
 import { assign, Machine } from 'xstate'
 
@@ -52,6 +52,8 @@ export const PieChartMachine = Machine(
 			hasNoSummary: {
 				on: {
 					[FETCH_SUMMARY]: { target: 'loading' },
+					[CHANGE_CLASS]: { target: 'idle' },
+					[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
 				},
 				activities: ['hasNoValues'],
 			},

--- a/src/components/Table/tableChartMachine.js
+++ b/src/components/Table/tableChartMachine.js
@@ -2,6 +2,7 @@ import hash from 'object-hash'
 import { fetchTable } from 'src/apiRequests'
 import { tableCache } from 'src/caches'
 import {
+	CHANGE_CLASS,
 	CHANGE_MINE,
 	CHANGE_PAGE,
 	FETCH_INITIAL_SUMMARY,
@@ -123,6 +124,7 @@ export const TableChartMachine = Machine(
 				activities: ['isLoading'],
 			},
 			fetchNewPages: {
+				activities: ['isLoading'],
 				invoke: {
 					id: 'fetchNewPages',
 					src: 'fetchNewPages',
@@ -136,7 +138,6 @@ export const TableChartMachine = Machine(
 							console.error('FETCH: Could not fetch new Table Rows', { ctx, event }),
 					},
 				},
-				activities: ['isLoading'],
 			},
 			noTableSummary: {
 				on: {
@@ -144,6 +145,8 @@ export const TableChartMachine = Machine(
 						target: 'fetchInitialRows',
 						actions: 'bustCachedPages',
 					},
+					[CHANGE_MINE]: { target: 'waitingOnMineToLoad' },
+					[CHANGE_CLASS]: { target: 'idle' },
 				},
 				activities: ['hasNoValues'],
 			},


### PR DESCRIPTION
When a chart was in an error state, for example when it doesn't receive
any values, it will stay there and not transition on new queries. This
occurred because the table machine would update the available selected
paths on each new query. And if it errors, then the paths would be reset
to an empty array.

This PR ensures that the paths are only updated when the mine changes,
and that the machines transition out of error states when the class or mine
changes as well.

Closes: #192 