### PR TITLE
Fix: set the classview for the barchart title

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -61,7 +61,9 @@ export const App = () => {
 								</AppManagerServiceContext.Provider>
 							</div>
 							<div css={{ height: '100%', width: '45%' }}>
-								<BarChart />
+								<AppManagerServiceContext.Provider value={service}>
+									<BarChart />
+								</AppManagerServiceContext.Provider>
 							</div>
 						</Card>
 					</section>

--- a/src/components/BarChart/barChartMachine.js
+++ b/src/components/BarChart/barChartMachine.js
@@ -48,8 +48,8 @@ export const BarChartMachine = Machine(
 			loading: {
 				activities: ['isLoading'],
 				invoke: {
-					id: 'fetchGeneLength',
-					src: 'fetchGeneLength',
+					id: 'fetchLengths',
+					src: 'fetchLengths',
 					onDone: {
 						target: 'idle',
 						actions: 'setLengthSummary',
@@ -85,7 +85,7 @@ export const BarChartMachine = Machine(
 			},
 		},
 		services: {
-			fetchGeneLength: async (_ctx, { classView, rootUrl, query: nextQuery }) => {
+			fetchLengths: async (_ctx, { classView, rootUrl, query: nextQuery }) => {
 				let query = {
 					...nextQuery,
 					from: classView,
@@ -120,8 +120,6 @@ export const BarChartMachine = Machine(
 				}
 
 				return {
-					classView,
-					rootUrl,
 					lengthStats: summary.stats,
 					lengthSummary: summary.results.slice(0, summary.results.length - 1),
 				}


### PR DESCRIPTION
The bar chart was displaying the class 'Gene', regardless of the chosen
class. This commit sets the class for the title and description for
non-ideal states, as well as for the title of the chart itself.

Closes: #194 