### PR TITLE
Display a notification if the class does not have a path available

### DIFF
--- a/src/apiRequests.js
+++ b/src/apiRequests.js
@@ -39,6 +39,14 @@ export const fetchSummary = async ({ rootUrl, query, path }) => {
 	return await q.summarize(fullPath)
 }
 
+export const verifyPath = async ({ rootUrl, classView, path }) => {
+	const service = getService(rootUrl)
+
+	const fullPath = formatConstraintPath({ classView, path })
+
+	return await service.makePath(fullPath)
+}
+
 export const fetchTable = async ({ rootUrl, query, page }) => {
 	const service = getService(rootUrl)
 	const summary = await service.tableRows(query, page)

--- a/src/components/BarChart/BarChart.jsx
+++ b/src/components/BarChart/BarChart.jsx
@@ -92,11 +92,18 @@ export const BarChart = React.memo(function BarChart() {
 		}
 	})
 
-	if (state.activities.hasNoValues) {
+	const { displayingNoValues, displayingNoPaths } = state.activities
+
+	if (displayingNoValues || displayingNoPaths) {
+		const description = displayingNoValues
+			? `The mine/class combination does not provide ${classView} lengths. If you feel this is an error, please contact support`
+			: `The class ${classView} does not contain lengths`
+
 		return (
 			<NonIdealStateWarning
-				title={`No lengths for ${classView} available`}
-				description={`The mine/class combination does not provide ${classView} lengths. If you feel this is an error, please contact support`}
+				title="No lengths available"
+				description={description}
+				isWarning={displayingNoValues ? true : false}
 			/>
 		)
 	}

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -1,8 +1,6 @@
 import { ProgressBar } from '@blueprintjs/core'
 import { useMachine } from '@xstate/react'
 import React from 'react'
-// use direct import because babel is not properly changing it in webpack
-import { useFirstMountState } from 'react-use/lib/useFirstMountState'
 import {
 	Cell,
 	Label,
@@ -62,8 +60,6 @@ const renderLoadingLabel = (props) => {
 }
 
 export const PieChart = React.memo(function PieChart() {
-	const isFirstRender = useFirstMountState()
-
 	const [state, , service] = useMachine(PieChartMachine)
 	const [appState] = usePartialContext('appManager', (ctx) => ({
 		classView: ctx.classView,
@@ -74,16 +70,21 @@ export const PieChart = React.memo(function PieChart() {
 	const { allClassOrganisms } = state.context
 	const { classView } = appState
 
-	const { isLoading, hasNoValues } = state.activities
+	const { isLoading, displayingNoValues, displayingNoPaths } = state.activities
 	const data = isLoading ? pieChartLoadingData : allClassOrganisms
 
-	if (hasNoValues) {
-		const title = isFirstRender ? 'No query has been executed' : 'No Organism Summary available'
-		const description = isFirstRender
-			? 'Define the constraints to the left, and execute a query to see visual data results'
+	if (displayingNoValues || displayingNoPaths) {
+		const description = displayingNoPaths
+			? `The class ${classView} does not contain organism summaries`
 			: 'The mine/class combination did not return any organism summaries. If you feel this an error, please contact support'
 
-		return <NonIdealStateWarning title={title} description={description} />
+		return (
+			<NonIdealStateWarning
+				isWarning={displayingNoValues ? true : false}
+				title="No Organism Summary available"
+				description={description}
+			/>
+		)
 	}
 
 	return (

--- a/src/components/Shared/NonIdealStates.jsx
+++ b/src/components/Shared/NonIdealStates.jsx
@@ -2,17 +2,22 @@ import { Classes, NonIdealState } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import React from 'react'
 
-export const NonIdealStateWarning = ({ title = '', description = '', className = '' }) => (
+export const NonIdealStateWarning = ({
+	title = '',
+	description = '',
+	className = '',
+	isWarning = true,
+}) => (
 	<NonIdealState
 		title={title}
 		description={description}
-		icon={IconNames.WARNING_SIGN}
+		icon={isWarning ? IconNames.WARNING_SIGN : IconNames.INFO_SIGN}
 		className={className}
 		css={{
 			paddingBottom: 32,
 			borderRadius: 3,
 			[`& .${Classes.NON_IDEAL_STATE_VISUAL}`]: {
-				color: 'var(--yellow5)',
+				color: isWarning ? 'var(--yellow5)' : 'var(--blue5)',
 			},
 		}}
 	/>


### PR DESCRIPTION
Some classes do not have a path available, yet are displaying a warning
when trying to process data for the charts. This is not ideal since these
classes not having those paths is a known state, and not an error.

This commit displays a standard notification stating the correct state
of the application.

Closes: #196 

![Screen Shot 2020-08-11 at 1 41 23 PM](https://user-images.githubusercontent.com/24993360/89930249-758fd200-dbd8-11ea-8070-d6617965554b.png)
