### PR TITLE
Do not display overview constraints that do not exist on class

### DIFF
--- a/src/apiRequests.js
+++ b/src/apiRequests.js
@@ -19,26 +19,21 @@ const getService = (rootUrl) => {
 
 export const INTERMINE_REGISTRY = 'https://registry.intermine.org/service/instances'
 
+/**
+ *
+ */
 export const fetchSummary = async ({ rootUrl, query, path }) => {
 	const service = getService(rootUrl)
 	const q = new imjs.Query(query, service)
 
-	let fullPath
-	try {
-		fullPath = formatConstraintPath({ classView: query.from, path })
-
-		// make sure the path exists
-		await service.makePath(fullPath)
-	} catch (e) {
-		const err = new Error()
-		err.message = `The mine at ${rootUrl} does not contain the path ${fullPath}`
-
-		throw err
-	}
+	const fullPath = formatConstraintPath({ classView: query.from, path })
 
 	return await q.summarize(fullPath)
 }
 
+/**
+ *
+ */
 export const verifyPath = async ({ rootUrl, classView, path }) => {
 	const service = getService(rootUrl)
 
@@ -47,6 +42,9 @@ export const verifyPath = async ({ rootUrl, classView, path }) => {
 	return await service.makePath(fullPath)
 }
 
+/**
+ *
+ */
 export const fetchTable = async ({ rootUrl, query, page }) => {
 	const service = getService(rootUrl)
 	const summary = await service.tableRows(query, page)
@@ -58,12 +56,18 @@ export const fetchTable = async ({ rootUrl, query, page }) => {
 	}
 }
 
+/**
+ *
+ */
 export const fetchTemplates = async ({ rootUrl }) => {
 	const service = getService(rootUrl)
 
 	return await service.fetchTemplates()
 }
 
+/**
+ *
+ */
 export const fetchInstances = async (registry) => {
 	return axios.get(registry, {
 		params: {
@@ -72,24 +76,36 @@ export const fetchInstances = async (registry) => {
 	})
 }
 
+/**
+ *
+ */
 export const fetchClasses = async (rootUrl) => {
 	const service = getService(rootUrl)
 
 	return await service.fetchModel()
 }
 
+/**
+ *
+ */
 export const fetchPathValues = async ({ path, rootUrl }) => {
 	const service = getService(rootUrl)
 
 	return await service.pathValues(path)
 }
 
+/**
+ *
+ */
 export const fetchLists = async (rootUrl) => {
 	const service = getService(rootUrl)
 
 	return await service.fetchLists()
 }
 
+/**
+ *
+ */
 export const exportTable = async ({ query, rootUrl, format, fileName, headers }) => {
 	const service = getService(rootUrl)
 	const q = await service.query(query)
@@ -110,6 +126,10 @@ export const exportTable = async ({ query, rootUrl, format, fileName, headers })
 
 	saveAs(blob, `${fileName}.${format}`)
 }
+
+/**
+ *
+ */
 export const fetchCode = async ({ query, fileExtension, rootUrl, codeCache, isSameQuery }) => {
 	if (!query || Object.keys(query).length === 0 || (isSameQuery && fileExtension in codeCache)) {
 		return

--- a/src/components/ConstraintSection/ConstraintSection.jsx
+++ b/src/components/ConstraintSection/ConstraintSection.jsx
@@ -11,6 +11,7 @@ import { sendToBus, useEventBus } from 'src/useEventBus'
 import { DATA_VIZ_COLORS } from '../dataVizColors'
 import { OverviewConstraint } from '../Overview/OverviewConstraint'
 import { QueryController } from '../QueryController/QueryController'
+import { NonIdealStateWarning } from '../Shared/NonIdealStates'
 import { TemplateQuery } from '../Templates/TemplateQuery'
 
 const ShowCategories = ({ categoryTagsForClass, handleCategoryToggle, showAll, showAllLabel }) => {
@@ -169,6 +170,21 @@ const OverviewConstraintList = ({ overviewActor }) => {
 			sendToBus({ type: FETCH_SUMMARY, query: lastOverviewQuery, classView, rootUrl })
 		}
 	})
+
+	const hasNoConstraints = constraintActors.every((actor) => {
+		return actor.state.activities.hidingConstraintFromView
+	})
+
+	if (hasNoConstraints) {
+		return (
+			<NonIdealStateWarning
+				title="No Constraints available"
+				description="The selected class does not provide constraints to edit"
+				isWarning={false}
+				styles={{ display: 'block', paddingTop: 100 }}
+			/>
+		)
+	}
 
 	return (
 		<ul

--- a/src/components/Shared/NonIdealStates.jsx
+++ b/src/components/Shared/NonIdealStates.jsx
@@ -7,6 +7,7 @@ export const NonIdealStateWarning = ({
 	description = '',
 	className = '',
 	isWarning = true,
+	styles = {},
 }) => (
 	<NonIdealState
 		title={title}
@@ -19,6 +20,7 @@ export const NonIdealStateWarning = ({
 			[`& .${Classes.NON_IDEAL_STATE_VISUAL}`]: {
 				color: isWarning ? 'var(--yellow5)' : 'var(--blue5)',
 			},
+			...styles,
 		}}
 	/>
 )


### PR DESCRIPTION
Some classes do not have constraints available, and we can tell which
they are. Yet right now we still load them and display a warning to the
user. But this isn't ideal since it is a known state, and not an error.

This commit will only render those constraints that are available for the
chosen class. When no constraints exist for the chosen class, a
notification will be displayed to the user.

Closes: #198 

![Screen Shot 2020-08-11 at 2 23 54 PM](https://user-images.githubusercontent.com/24993360/89934298-5d22b600-dbde-11ea-897c-181cdd118658.png)
